### PR TITLE
fix(ci): update tests for lib.rs refactor and Rocky Linux 9

### DIFF
--- a/.github/workflows/rocky-test.yml
+++ b/.github/workflows/rocky-test.yml
@@ -13,9 +13,9 @@ concurrency:
 
 jobs:
   test:
-    name: Rocky Linux 10 Build & Test
+    name: Rocky Linux 9 Build & Test
     runs-on: ubuntu-latest
-    container: rockylinux:10
+    container: rockylinux:9
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/test/week14-integration-test.el
+++ b/test/week14-integration-test.el
@@ -28,22 +28,22 @@
            (expand-file-name "compositor/src/secure_input.rs"
                              (locate-dominating-file default-directory ".git")))))
 
-;; ── Rust modules declared in main.rs ──────────────────────
+;; ── Rust modules declared in lib.rs ───────────────────────
 
 (ert-deftest week14/main-declares-autotype ()
-  "main.rs declares autotype module."
+  "lib.rs declares autotype module."
   (let* ((root (locate-dominating-file default-directory ".git"))
-         (main-rs (expand-file-name "compositor/src/main.rs" root)))
+         (lib-rs (expand-file-name "compositor/src/lib.rs" root)))
     (with-temp-buffer
-      (insert-file-contents main-rs)
+      (insert-file-contents lib-rs)
       (should (search-forward "pub mod autotype;" nil t)))))
 
 (ert-deftest week14/main-declares-secure-input ()
-  "main.rs declares secure_input module."
+  "lib.rs declares secure_input module."
   (let* ((root (locate-dominating-file default-directory ".git"))
-         (main-rs (expand-file-name "compositor/src/main.rs" root)))
+         (lib-rs (expand-file-name "compositor/src/lib.rs" root)))
     (with-temp-buffer
-      (insert-file-contents main-rs)
+      (insert-file-contents lib-rs)
       (should (search-forward "pub mod secure_input;" nil t)))))
 
 ;; ── State has new fields ───────────────────────────────────

--- a/test/week20-integration-test.el
+++ b/test/week20-integration-test.el
@@ -29,20 +29,20 @@
     (should (string-match-p "0\\.1\\.0" content))))
 
 (ert-deftest week20/plan-exists ()
-  "PLAN.md exists."
+  "PLAN.md removed; feature-matrix.md replaces it."
   (should (file-exists-p
-           (expand-file-name "PLAN.md" week20-test--root))))
+           (expand-file-name "docs/feature-matrix.md" week20-test--root))))
 
 (ert-deftest week20/justfile-exists ()
-  "Justfile exists."
+  "justfile exists."
   (should (file-exists-p
-           (expand-file-name "Justfile" week20-test--root))))
+           (expand-file-name "justfile" week20-test--root))))
 
 (ert-deftest week20/justfile-has-release-recipe ()
-  "Justfile contains release recipe."
+  "justfile contains release recipe."
   (let ((content (with-temp-buffer
                    (insert-file-contents
-                    (expand-file-name "Justfile" week20-test--root))
+                    (expand-file-name "justfile" week20-test--root))
                    (buffer-string))))
     (should (string-match-p "release" content))))
 

--- a/test/week7-integration-test.el
+++ b/test/week7-integration-test.el
@@ -115,11 +115,11 @@
       (should (search-forward "vr_state" nil t)))))
 
 (ert-deftest week7-integration/main-has-vr-mod ()
-  "Compositor main.rs declares vr module."
-  (let ((main-file (expand-file-name "compositor/src/main.rs"
-                                      (locate-dominating-file default-directory ".git"))))
+  "Compositor lib.rs declares vr module."
+  (let ((lib-file (expand-file-name "compositor/src/lib.rs"
+                                     (locate-dominating-file default-directory ".git"))))
     (with-temp-buffer
-      (insert-file-contents main-file)
+      (insert-file-contents lib-file)
       (should (search-forward "pub mod vr;" nil t)))))
 
 ;;; week7-integration-test.el ends here


### PR DESCRIPTION
## Summary
- Fix 6 ERT test failures caused by v0.2.0 `main.rs` -> `lib.rs` refactor
- Fix Rocky Linux container (use `rockylinux:9`, 10 not released yet)

## Fixes
- `week14/main-declares-autotype` + `week14/main-declares-secure-input`: check `lib.rs`
- `week7-integration/main-has-vr-mod`: check `lib.rs`
- `week20/plan-exists`: check `docs/feature-matrix.md` (PLAN.md removed)
- `week20/justfile-exists` + `week20/justfile-has-release-recipe`: lowercase `justfile`
- Rocky Linux workflow: `rockylinux:9` image