### PR TITLE
Document current XoxdWM status and tighten CI surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a reproducible problem on a named host or packaging path.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: dropdown
+    id: support_state
+    attributes:
+      label: Support State
+      description: How should this area currently be treated?
+      options:
+        - Proven
+        - Smoke
+        - Design
+    validations:
+      required: true
+  - type: input
+    id: host
+    attributes:
+      label: Host
+      description: Use a real host name when possible, such as honey or yoga.
+      placeholder: honey
+  - type: input
+    id: kernel
+    attributes:
+      label: Kernel
+      placeholder: 6.19.5-5.xr.el10
+  - type: input
+    id: gpu
+    attributes:
+      label: GPU
+      placeholder: Radeon RX 9070 XT
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Exact steps and commands.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support Matrix
+    url: https://github.com/Jesssullivan/XoxdWM/blob/main/docs/support-matrix.md
+    about: Check the current Proven / Smoke / Design status before filing feature support issues.
+  - name: Status
+    url: https://github.com/Jesssullivan/XoxdWM/blob/main/docs/status.md
+    about: Review the current repo status and near-term priorities.

--- a/.github/ISSUE_TEMPLATE/mvp-epic.yml
+++ b/.github/ISSUE_TEMPLATE/mvp-epic.yml
@@ -1,0 +1,32 @@
+name: MVP Epic
+description: Track a named-host milestone or 12-week execution item.
+title: "epic: "
+labels:
+  - epic
+body:
+  - type: input
+    id: target
+    attributes:
+      label: Target
+      placeholder: yoga Rocky 10 desktop install
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired Outcome
+      description: What will be demonstrably true when this epic is done?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Keep this concrete and testable.
+    validations:
+      required: true
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Known Blockers
+      description: External dependencies, hardware gaps, or upstream assumptions.

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "audit",
+    "color": "d4c5f9",
+    "description": "Reality-audit and support-matrix work"
+  },
+  {
+    "name": "mvp",
+    "color": "0e8a16",
+    "description": "Work required for the named-host MVP"
+  },
+  {
+    "name": "vr",
+    "color": "1d76db",
+    "description": "VR compositor, OpenXR, and HMD integration work"
+  },
+  {
+    "name": "bci",
+    "color": "5319e7",
+    "description": "BCI and biosignal integration work"
+  },
+  {
+    "name": "docs",
+    "color": "fbca04",
+    "description": "Documentation, support matrix, and status surfaces"
+  },
+  {
+    "name": "packaging",
+    "color": "0052cc",
+    "description": "RPM, DEB, Nix, and service packaging work"
+  },
+  {
+    "name": "hardware",
+    "color": "d93f0b",
+    "description": "Named-host and device-specific work"
+  },
+  {
+    "name": "ci",
+    "color": "c2e0c6",
+    "description": "GitHub Actions and runner automation work"
+  }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,28 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    paths:
+      - 'compositor/**'
+      - 'lisp/**'
+      - 'nix/**'
+      - 'test/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'justfile'
+      - '.github/workflows/ci.yml'
+      - '.github/actions/**'
   pull_request:
     branches: [main, dev]
+    paths:
+      - 'compositor/**'
+      - 'lisp/**'
+      - 'nix/**'
+      - 'test/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'justfile'
+      - '.github/workflows/ci.yml'
+      - '.github/actions/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -25,7 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - name: Install Nix
+        if: vars.USE_SELFHOSTED != 'true'
+        uses: cachix/install-nix-action@v30
+      - name: Verify Nix
+        run: nix --version
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/rocky-test.yml
+++ b/.github/workflows/rocky-test.yml
@@ -44,19 +44,11 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-      - name: Setup sccache
-        uses: ./.github/actions/setup-sccache
-
       - name: Build headless compositor
         run: cargo build --manifest-path compositor/Cargo.toml --no-default-features
 
       - name: Run Rust tests (headless)
         run: cargo test --manifest-path compositor/Cargo.toml --no-default-features
-
-      - name: sccache stats
-        if: always()
-        shell: bash
-        run: command -v sccache &>/dev/null && sccache --show-stats || echo "sccache not active"
 
       - name: Run ERT tests
         run: |

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -3,8 +3,8 @@ name: Runner Health Check
 on:
   workflow_dispatch:
   schedule:
-    # Daily at 06:00 UTC
-    - cron: '0 6 * * *'
+    # Weekly Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: runner-health

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -7,8 +7,28 @@ name: Self-Hosted Fast CI
 on:
   push:
     branches: [main, dev, 'feature/*']
+    paths:
+      - 'compositor/**'
+      - 'lisp/**'
+      - 'nix/**'
+      - 'test/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'justfile'
+      - '.github/workflows/self-hosted-fast.yml'
+      - '.github/actions/**'
   pull_request:
     branches: [main, dev]
+    paths:
+      - 'compositor/**'
+      - 'lisp/**'
+      - 'nix/**'
+      - 'test/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'justfile'
+      - '.github/workflows/self-hosted-fast.yml'
+      - '.github/actions/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,63 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/labels.json'
+      - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync repository labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const labels = JSON.parse(fs.readFileSync('.github/labels.json', 'utf8'));
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const byName = new Map(existing.map((label) => [label.name, label]));
+
+            for (const label of labels) {
+              const current = byName.get(label.name);
+              if (current) {
+                const currentDescription = current.description || '';
+                if (
+                  current.color.toLowerCase() !== label.color.toLowerCase() ||
+                  currentDescription !== label.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner,
+                    repo,
+                    name: current.name,
+                    new_name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              } else {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              }
+            }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# XoxdWM
+
+XoxdWM is an experimental Wayland compositor plus Emacs window-management layer with VR, eye-tracking, hand-tracking, and BCI research surfaces.
+
+This repository is the canonical public home for the compositor, packaging, releases, and status tracking. It is not a claim that every documented subsystem is proven on lab hardware today.
+
+## Current State
+
+As of 2026-04-11:
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Release artifacts | Smoke | `v0.5.0` publishes RPM and DEB artifacts. |
+| Headless compositor path | Smoke | Build and test surfaces exist, but not re-validated in this pass. |
+| Rocky 10 package install | Smoke | Packaging exists; quickstart now documents it as a compositor/package path, not a full VR deployment. |
+| `honey` VR session | Design | `honey` has OpenXR libs and disabled Monado units, but no deployed XoxdWM stack. |
+| `yoga` desktop/dev target | Design | `yoga` is still on stock Rocky 10 and has no XoxdWM install. |
+| Eye tracking / hand tracking / BCI | Design | Documented and partially implemented, but not currently claimed as proven on named lab hosts. |
+
+## Start Here
+
+- [Support Matrix](docs/support-matrix.md)
+- [Status](docs/status.md)
+- [Q2 2026 Roadmap](docs/roadmap-2026-q2.md)
+- [Installation Quickstart](docs/installation-quickstart.md)
+- [VR Guide](docs/vr-guide.md)
+
+## Scope
+
+The repo contains four different kinds of work:
+
+- compositor and Emacs WM code
+- packaging for Rocky/Nix/systemd/SELinux
+- hardware and upstream patch research
+- aspirational feature inventory
+
+Only the support matrix and status docs should be read as the current operational truth.
+
+## Releases
+
+Latest public release:
+
+- [`v0.5.0`](https://github.com/Jesssullivan/XoxdWM/releases/tag/v0.5.0)
+
+Current public install artifacts:
+
+- `ewwm-compositor-*.x86_64.rpm`
+- `ewwm-compositor_*_amd64.deb`
+
+These artifacts currently package the compositor path. They do not, by themselves, establish a proven full VR deployment on `honey` or `yoga`.
+
+## Near-Term Goal
+
+The next 12 weeks are aimed at one honest MVP:
+
+- `yoga`: reproducible Rocky 10 desktop/dev install
+- `honey`: VR smoke path with Monado, non-desktop HMD detection, and compositor launch
+
+Everything else remains secondary until those two named-host outcomes are green.

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -1,7 +1,8 @@
 # XoxdWM (EXWM-VR) Feature Matrix
 
-Comprehensive reference for all IPC commands, subsystems, platform support,
-hardware requirements, and module inventory as of v0.1.0.
+Comprehensive reference for IPC commands, subsystems, and module inventory.
+
+This document is an inventory, not a support promise. For the current operational truth, read [Support Matrix](support-matrix.md) first.
 
 ---
 

--- a/docs/installation-quickstart.md
+++ b/docs/installation-quickstart.md
@@ -1,5 +1,11 @@
 # XoxdWM Installation Quickstart
 
+This quickstart is intentionally narrower than the feature inventory.
+
+- For current support claims, read [Support Matrix](support-matrix.md).
+- For the repo’s current operational status, read [Status](status.md).
+- As of 2026-04-11, the Rocky path is a compositor/package path, not a claimed full VR deployment on `honey` or `yoga`.
+
 ## NixOS (Declarative)
 
 Add to your `flake.nix` inputs:
@@ -29,6 +35,8 @@ Home Manager (user config):
 
 ## Rocky Linux / Fedora (RPM)
 
+This installs the released compositor package. It does not, by itself, provision a proven full VR stack.
+
 Download from GitHub Releases:
 ```bash
 curl -LO https://github.com/Jesssullivan/XoxdWM/releases/latest/download/ewwm-compositor-*.x86_64.rpm
@@ -38,7 +46,7 @@ sudo dnf install ./ewwm-compositor-*.x86_64.rpm
 Install Emacs and enable the session:
 ```bash
 sudo dnf install emacs
-# Log out, select "EWWM" session at login screen
+# Log out, select "EXWM-VR" session at login screen if the session file is installed
 ```
 
 ## Debian / Ubuntu (DEB)
@@ -60,7 +68,8 @@ cargo build --release --manifest-path compositor/Cargo.toml
 # Install
 sudo install -Dm755 compositor/target/release/ewwm-compositor /usr/local/bin/
 sudo install -Dm644 packaging/systemd/exwm-vr-compositor.service /usr/lib/systemd/user/
-sudo install -Dm644 packaging/desktop/ewwm.desktop /usr/share/wayland-sessions/
+sudo install -Dm644 packaging/desktop/exwm-vr.desktop /usr/share/wayland-sessions/exwm-vr.desktop
+sudo install -Dm755 packaging/desktop/exwm-vr-session /usr/share/exwm-vr/exwm-vr-session
 
 # Emacs packages
 sudo mkdir -p /usr/share/emacs/site-lisp/exwm{,-vr}
@@ -88,3 +97,8 @@ ewwm-compositor --backend headless --headless-exit-after 5
 # Run ERT test suite
 emacs --batch -L lisp/core -L lisp/vr -L lisp/ext -l test/run-tests.el
 ```
+
+## Named-Host Guidance
+
+- `yoga`: target desktop/dev host for the next reproducible Rocky 10 install path.
+- `honey`: target VR smoke host, but not currently documented here as a proven XoxdWM deployment.

--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -1,0 +1,46 @@
+# XoxdWM Roadmap: Q2 2026
+
+This document is the execution-side counterpart to the support matrix.
+
+## Epic 1: Reality Audit And Support Surface
+
+Goal: keep the public repo honest.
+
+Acceptance:
+
+- root README exists and points to current status docs
+- support matrix is maintained
+- install docs distinguish package availability from named-host validation
+- aspirational subsystems are not described as supported by default
+
+## Epic 2: CI Recovery
+
+Goal: restore a reliable critical path for code changes.
+
+Acceptance:
+
+- docs-only pushes do not trigger heavy self-hosted workflows
+- Rocky test no longer fails in optional cache setup
+- self-hosted Nix workflows stop reinstalling Nix on provisioned runners
+- weekly runner-health remains available without dominating repo signal
+
+## Epic 3: Rocky 10 Desktop/Dev MVP On `yoga`
+
+Goal: produce a documented install path for the compositor on a real Rocky 10 lab machine.
+
+Acceptance:
+
+- `yoga` can install the public package or build from source with documented steps
+- compositor launch path is documented and repeatable
+- rollback path is documented if package install fails
+
+## Epic 4: `honey` VR Smoke Path
+
+Goal: prove a minimal VR lifecycle on the current kernel host.
+
+Acceptance:
+
+- Monado and required userspace are installed and documented
+- HMD enumeration is observed as expected
+- compositor starts on the target host
+- one smoke path for DRM lease / OpenXR startup is recorded in repo docs

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,34 @@
+# XoxdWM Status
+
+Snapshot date: 2026-04-11
+
+## Honest Assessment
+
+- The repo has a real public release and substantial packaging work.
+- The repo did not have a root README describing current support state.
+- `honey` is not currently running a deployed XoxdWM stack.
+- `yoga` is not currently running a deployed XoxdWM stack.
+- Recent push CI failures were concentrated in three places:
+  - Rocky test: optional `sccache` setup step
+  - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
+  - self-hosted fast CI: heavy checks on all pushes, including non-code work
+
+## What This Repo Is Good For Right Now
+
+- tracking compositor and packaging work in public
+- publishing experimental package artifacts
+- carrying the userspace side of Rocky 10 / Wayland / VR integration work
+- serving as the research and implementation repo for the `honey` and `yoga` MVP paths
+
+## What This Repo Is Not Claiming Right Now
+
+- daily-driver VR on `honey`
+- a complete turnkey Rocky 10 VR deployment
+- proven eye tracking, hand tracking, or BCI support on current named lab hosts
+
+## Immediate Priorities
+
+1. Restore a green critical CI path for code changes.
+2. Keep the public docs honest and scoped to `Proven`, `Smoke`, and `Design`.
+3. Produce one reproducible Rocky 10 desktop/dev install on `yoga`.
+4. Produce one reproducible `honey` VR smoke path.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,59 @@
+# XoxdWM Support Matrix
+
+This matrix is the operational truth for the repo.
+
+Status vocabulary:
+
+- `Proven`: repeatably validated on a named host or in stable automation.
+- `Smoke`: packaged or manually validated once, but not yet a stable supported lane.
+- `Design`: code/docs/research exist, but the flow is not yet claimed as working on a named target.
+
+Date baseline: 2026-04-11.
+
+## Named Hosts
+
+| Target | Status | Notes |
+| --- | --- | --- |
+| `honey` kernel | Proven | Running `6.19.5-5.xr.el10`. |
+| `honey` XoxdWM compositor install | Design | No deployed XoxdWM packages found. |
+| `honey` OpenXR userspace prereqs | Smoke | `openxr-libs` present; `monado.service` exists but is disabled. |
+| `honey` VR session | Design | Not yet claimed as working end-to-end. |
+| `yoga` kernel | Proven | Running stock Rocky 10 kernel. |
+| `yoga` XoxdWM install | Design | No XoxdWM/OpenXR packages found. |
+| `petting-zoo-mini` | Out of scope | Not a current Linux XR validation target. |
+
+## Packaging And Install Surfaces
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| GitHub release RPM | Smoke | Public release exists and ships `ewwm-compositor`. |
+| GitHub release DEB | Smoke | Public release exists. |
+| Nix flake outputs | Smoke | Build surfaces exist; critical push CI is not green yet. |
+| Rocky 10 quickstart | Smoke | Documented as compositor/package path only. |
+| NixOS / Home Manager module | Smoke | Present in repo, but not claimed as proven in this audit. |
+
+## Runtime Areas
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Headless compositor | Smoke | Explicit build/test path exists. |
+| Desktop 2D compositor path | Smoke | Packaged, but not yet named-host validated in this pass. |
+| DRM backend on AMD | Smoke | Code and workflows exist; host validation remains pending. |
+| VR session lifecycle | Design | Not yet claimed as working on `honey`. |
+| DRM lease / HMD non-desktop handling | Design | Code exists; validation still pending. |
+| Eye tracking | Design | Documented and implemented in part; no named-host support claim. |
+| Hand tracking / gestures | Design | Same. |
+| BCI / BrainFlow | Design | Same. |
+
+## CI
+
+| Workflow Area | Status | Notes |
+| --- | --- | --- |
+| Lightweight CI on code changes | Smoke | Kept as primary CI surface. |
+| Rocky Linux test | Smoke | Workflow exists; current failure was isolated to optional `sccache` setup. |
+| Self-hosted fast CI | Smoke | Still useful, but no longer triggered for docs-only changes. |
+| Scheduled runner health | Smoke | Reduced to weekly to avoid daily noise dominating repo health. |
+
+## Interpretation
+
+The feature matrix is a subsystem inventory, not a support promise. If a capability is not listed here as `Proven` or `Smoke`, treat it as `Design` regardless of how detailed the subsystem docs are.


### PR DESCRIPTION
## Summary
- add an honest status surface with README, support matrix, status, and Q2 roadmap docs
- add issue templates for bug reports and MVP epics
- tighten CI triggers so docs-only changes do not fan out into heavy workflows
- add label sync so the repo taxonomy is reproducible after merge
- remove the optional Rocky sccache setup and avoid reinstalling Nix on self-hosted runners in nix-cache

## Why
This makes XoxdWM read as an accurate public status repo, reduces avoidable CI noise, and creates the issue-management surface for the next 12 weeks of work.

## Validation
- parsed modified workflow YAML and issue template YAML with Ruby YAML.load_file
- git diff --check
