### PR TITLE
Scope self-hosted CI to available runner infra

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   warm-nix-cache:
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true'
+        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
         uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -58,7 +58,7 @@ jobs:
           done
 
       - name: Build cross targets
-        if: vars.USE_SELFHOSTED == 'true'
+        if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
         run: |
           echo "=== Cross-building aarch64 compositor ==="
           nix build .#packages.aarch64-linux.compositor --out-link result-aarch64 || true
@@ -70,7 +70,7 @@ jobs:
           nix build .#packages.s390x-linux.compositor-headless --out-link result-s390x || true
 
       - name: Push cross targets to Attic
-        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true'
+        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
         run: |
           for link in result-aarch64 result-aarch64-headless result-s390x; do
             if [ -L "$link" ]; then

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-x86_64:
     name: Build x86_64 (full + VR)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
 
   build-headless:
     name: Build x86_64 (headless)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
 
   ert-tests:
     name: ERT Tests
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
 
   cross-aarch64:
     name: Cross-compile aarch64
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     continue-on-error: true
     steps:
@@ -136,7 +136,7 @@ jobs:
 
   cross-s390x:
     name: Cross-compile s390x
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     continue-on-error: true
     steps:

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -32,7 +32,7 @@ jobs:
   # ── Nix build (self-hosted) ──────────────────────────────
   nix-build:
     name: Nix Build (wlroots + sway)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -20,13 +20,13 @@ concurrency:
 jobs:
   build:
     name: Nix Build
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true'
+        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
         uses: cachix/install-nix-action@v30
       - name: Verify Nix
         run: nix --version

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-binary:
     name: Build Compositor Binary
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   nix-runner:
     name: Nix Runner Health
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
     name: VR Runner Health
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
-    if: vars.USE_SELFHOSTED == 'true'
+    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
     steps:
       - name: Runner info
         run: |

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   fast-check:
     name: Fast Check (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true'
+    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   fast-build:
     name: Fast Build (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true'
+    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
@@ -138,7 +138,7 @@ jobs:
 
   fast-vr:
     name: Fast VR Smoke (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true'
+    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
     needs: fast-build
     runs-on: [self-hosted, honey]
     timeout-minutes: 10

--- a/.github/workflows/vr-hardware.yml
+++ b/.github/workflows/vr-hardware.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   preflight:
     name: Hardware Preflight
+    if: github.repository == 'tinyland-inc/XoxdWM'
     runs-on: [self-hosted, honey]
     timeout-minutes: 5
     steps:
@@ -58,6 +59,7 @@ jobs:
 
   compositor-gpu:
     name: Compositor GPU Build & Test
+    if: github.repository == 'tinyland-inc/XoxdWM'
     needs: preflight
     runs-on: [self-hosted, honey]
     timeout-minutes: 30
@@ -84,10 +86,10 @@ jobs:
 
   vr-session:
     name: VR Session Lifecycle
+    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
-    if: inputs.test-suite == 'full' || github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
 
@@ -123,10 +125,10 @@ jobs:
 
   drm-lease:
     name: DRM Lease Detection
+    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite != 'smoke' || github.ref_type == 'tag')
     needs: preflight
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
-    if: inputs.test-suite != 'smoke' || github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
 
@@ -158,10 +160,10 @@ jobs:
 
   eye-tracking:
     name: Eye Tracking E2E
+    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
-    if: inputs.test-suite == 'full' || github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
 
@@ -201,10 +203,10 @@ jobs:
 
   benchmark:
     name: GPU Benchmark
+    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 20
-    if: inputs.test-suite == 'full' || github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -23,6 +23,7 @@ Acceptance:
 - Rocky test no longer fails in optional cache setup
 - self-hosted Nix workflows stop reinstalling Nix on provisioned runners
 - weekly runner-health remains available without dominating repo signal
+- self-hosted jobs do not target unavailable `tinyland-inc/XoxdWM` runner scope from the current `Jesssullivan/XoxdWM` repo
 
 ## Epic 3: Rocky 10 Desktop/Dev MVP On `yoga`
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,6 +12,10 @@ Snapshot date: 2026-04-11
   - Rocky test: optional `sccache` setup step
   - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
   - self-hosted fast CI: heavy checks on all pushes, including non-code work
+- Current self-hosted runner scope does not match the current public repo:
+  - historical self-hosted evidence on `honey` points at `tinyland-inc/XoxdWM`
+  - live runners we found are registered to `tinyland-inc`, `Jesssullivan/cmux`, `Jesssullivan/outbot-ci`, and `Jesssullivan/chapel`
+  - we did not find a runner registration that can accept jobs from `Jesssullivan/XoxdWM`
 
 ## What This Repo Is Good For Right Now
 


### PR DESCRIPTION
## Summary
- stop targeting self-hosted runners unless the repo is actually `tinyland-inc/XoxdWM`, which is where the historical runner evidence points
- keep fallback workflows on GitHub-hosted runners for the current `Jesssullivan/XoxdWM` repo
- skip pure self-hosted honey workflows on the current repo instead of letting them queue forever
- record the repo-scope mismatch in status and roadmap docs

## Why
The live runner evidence does not support the current repo scope:
- `honey` has runners for `tinyland-inc`, `Jesssullivan/cmux`, and `Jesssullivan/outbot-ci`
- `petting-zoo-mini` has a repo-scoped runner for `Jesssullivan/chapel`
- `yoga` has no runner
- we did not find a runner registration that can accept `Jesssullivan/XoxdWM` jobs

## Validation
- parsed all touched workflow YAML files with Ruby `YAML.load_file`
- `git diff --check`
