### PR TITLE
Document current honey and yoga XR reality

### DIFF
--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -29,6 +29,11 @@ Acceptance:
 
 Goal: produce a documented install path for the compositor on a real Rocky 10 lab machine.
 
+Current reality:
+
+- `yoga` has a validated one-time `kernel-xr` boot path.
+- `yoga` still has no installed Monado/OpenXR/XoxdWM userspace stack.
+
 Acceptance:
 
 - `yoga` can install the public package or build from source with documented steps
@@ -39,9 +44,15 @@ Acceptance:
 
 Goal: prove a minimal VR lifecycle on the current kernel host.
 
+Current reality:
+
+- `honey` has a proven generic `linux-xr` default and a one-time verified RT lane.
+- `honey` has a Monado runtime manifest and `monado-service`, but not the OpenXR client tooling or compositor deployment needed for a real smoke path.
+
 Acceptance:
 
 - Monado and required userspace are installed and documented
-- HMD enumeration is observed as expected
+- an OpenXR client tool path exists and is documented on-host
+- HMD enumeration is observed as expected, or the lack of attached VR hardware is explicitly recorded as the blocker
 - compositor starts on the target host
 - one smoke path for DRM lease / OpenXR startup is recorded in repo docs

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,13 +1,17 @@
 # XoxdWM Status
 
-Snapshot date: 2026-04-11
+Snapshot date: 2026-04-12
 
 ## Honest Assessment
 
 - The repo has a real public release and substantial packaging work.
-- The repo did not have a root README describing current support state.
+- The repo now has a root README and status surface, but the named-host runtime reality still trails the packaging story.
 - `honey` is not currently running a deployed XoxdWM stack.
+- `honey` now has a proven `linux-xr` kernel default and a one-time verified PREEMPT_RT boot, but the VR userspace is still incomplete.
+- `honey` has partial XR prereqs only: `openxr-libs`, `openxr-devel`, `wlroots`, `wlroots-devel`, `/usr/local/bin/monado-service`, and `/usr/local/share/openxr/1/openxr_monado.json`.
+- `honey` does not currently expose `openxr-info`, `xrgears`, or `xoxdwm`, and no active DRM connector or obvious HMD path was present during the audit.
 - `yoga` is not currently running a deployed XoxdWM stack.
+- `yoga` now has a one-time validated `kernel-xr` boot path, but stock Rocky remains the persistent default and no XR userspace stack is installed.
 - Recent push CI failures were concentrated in three places:
   - Rocky test: optional `sccache` setup step
   - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
@@ -22,17 +26,18 @@ Snapshot date: 2026-04-11
 - tracking compositor and packaging work in public
 - publishing experimental package artifacts
 - carrying the userspace side of Rocky 10 / Wayland / VR integration work
-- serving as the research and implementation repo for the `honey` and `yoga` MVP paths
+- serving as the research and implementation repo for the `honey` and `yoga` MVP paths now that both hosts have validated kernel lanes
 
 ## What This Repo Is Not Claiming Right Now
 
 - daily-driver VR on `honey`
 - a complete turnkey Rocky 10 VR deployment
+- a working named-host XoxdWM compositor install on `honey` or `yoga`
 - proven eye tracking, hand tracking, or BCI support on current named lab hosts
 
 ## Immediate Priorities
 
-1. Restore a green critical CI path for code changes.
-2. Keep the public docs honest and scoped to `Proven`, `Smoke`, and `Design`.
-3. Produce one reproducible Rocky 10 desktop/dev install on `yoga`.
-4. Produce one reproducible `honey` VR smoke path.
+1. Put a real XoxdWM/Monado/OpenXR client-tool install path on `honey`, not just a bare Monado runtime manifest.
+2. Produce the first named-host compositor startup on either `honey` or `yoga`.
+3. Produce one reproducible Rocky 10 XR userspace install on `yoga`.
+4. Keep the public docs honest and CI aligned with the current repo runner scope.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -8,18 +8,20 @@ Status vocabulary:
 - `Smoke`: packaged or manually validated once, but not yet a stable supported lane.
 - `Design`: code/docs/research exist, but the flow is not yet claimed as working on a named target.
 
-Date baseline: 2026-04-11.
+Date baseline: 2026-04-12.
 
 ## Named Hosts
 
 | Target | Status | Notes |
 | --- | --- | --- |
-| `honey` kernel | Proven | Running `6.19.5-5.xr.el10`. |
-| `honey` XoxdWM compositor install | Design | No deployed XoxdWM packages found. |
-| `honey` OpenXR userspace prereqs | Smoke | `openxr-libs` present; `monado.service` exists but is disabled. |
-| `honey` VR session | Design | Not yet claimed as working end-to-end. |
-| `yoga` kernel | Proven | Running stock Rocky 10 kernel. |
-| `yoga` XoxdWM install | Design | No XoxdWM/OpenXR packages found. |
+| `honey` kernel generic lane | Proven | Running `6.19.5-7.xr.el10`; this is the persistent default. |
+| `honey` kernel RT lane | Smoke | One-time boot into `6.19.5-rt1-8.xr.el10` succeeded and live `PREEMPT_RT` was verified, but RT is not the default lane. |
+| `honey` XoxdWM compositor install | Design | No `xoxdwm` binary or host checkout was found. |
+| `honey` OpenXR userspace prereqs | Smoke | `openxr-libs`, `openxr-devel`, `wlroots`, `wlroots-devel`, `monado-service`, and `/usr/local/share/openxr/1/openxr_monado.json` are present. |
+| `honey` VR session | Design | No active DRM connector or obvious HMD path was observed, and no OpenXR client tools were installed. |
+| `yoga` kernel-xr boot path | Smoke | One-time boot into `6.19.5-8.xr.el10` succeeded; normal reboot returned to the saved stock Rocky default. |
+| `yoga` XoxdWM install | Design | No XoxdWM binary or package install was found. |
+| `yoga` OpenXR userspace prereqs | Design | No Monado/OpenXR/wlroots runtime packages or runtime manifest were found. |
 | `petting-zoo-mini` | Out of scope | Not a current Linux XR validation target. |
 
 ## Packaging And Install Surfaces
@@ -51,7 +53,7 @@ Date baseline: 2026-04-11.
 | --- | --- | --- |
 | Lightweight CI on code changes | Smoke | Kept as primary CI surface. |
 | Rocky Linux test | Smoke | Workflow exists; current failure was isolated to optional `sccache` setup. |
-| Self-hosted fast CI | Smoke | Still useful, but no longer triggered for docs-only changes. |
+| Self-hosted fast CI | Smoke | Still useful, but now skips cleanly on `Jesssullivan/XoxdWM` when no matching self-hosted runner scope exists. |
 | Scheduled runner health | Smoke | Reduced to weekly to avoid daily noise dominating repo health. |
 
 ## Interpretation


### PR DESCRIPTION
## Summary
- update status docs with the validated honey and yoga host findings
- record that honey has partial Monado/OpenXR prereqs but no deployed XoxdWM or client tooling
- record that yoga has validated kernel work but no XR userspace stack yet

## Validation
- audited honey and yoga over SSH
- verified doc-only diff with git diff --check
