### PR TITLE
Guard Rocky RPM release artifacts

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install rpmbuild dependencies
         run: |
-          dnf install -y rpm-build rpmdevtools gcc make \
+          dnf install -y rpm-build rpmdevtools gcc make cpio binutils \
             rust cargo pkgconfig \
             wayland-devel mesa-libEGL-devel mesa-libgbm-devel \
             libinput-devel libxkbcommon-devel libdrm-devel \
@@ -126,6 +126,37 @@ jobs:
             --define "version ${VERSION}" \
             --define "_version ${VERSION}" \
             packaging/rpm/exwm-vr.spec
+
+      - name: Validate RPM runtime metadata
+        run: |
+          set -euo pipefail
+          RPM=$(find ~/rpmbuild/RPMS -name 'ewwm-compositor-*.rpm' | head -1)
+          if [ -z "$RPM" ]; then
+            echo "No ewwm-compositor RPM found in rpmbuild output" >&2
+            exit 1
+          fi
+
+          mkdir -p /tmp/rpm-validate
+          pushd /tmp/rpm-validate >/dev/null
+          rpm2cpio "$RPM" | cpio -idmv "./usr/bin/ewwm-compositor" >/dev/null 2>&1
+          BIN=usr/bin/ewwm-compositor
+
+          if readelf -l "$BIN" | grep -q '/nix/store'; then
+            echo "RPM binary uses a /nix/store ELF interpreter; expected native Rocky runtime linking" >&2
+            exit 1
+          fi
+
+          if readelf -d "$BIN" | grep -q '/nix/store'; then
+            echo "RPM binary embeds a /nix/store RUNPATH; expected native Rocky runtime linking" >&2
+            exit 1
+          fi
+
+          if rpm -qpR "$RPM" | grep -Fxq 'wayland'; then
+            echo "RPM has unresolved bare 'wayland' dependency metadata; expected native Rocky library/runtime package deps" >&2
+            exit 1
+          fi
+
+          popd >/dev/null
 
       - name: Collect RPMs
         run: |

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This repository is the canonical public home for the compositor, packaging, rele
 
 ## Current State
 
-As of 2026-04-11:
+As of 2026-04-12:
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| Release artifacts | Smoke | `v0.5.0` publishes RPM and DEB artifacts. |
+| Release artifacts | Smoke | `v0.5.0` publishes RPM and DEB artifacts, but the Rocky RPM is not yet a proven host-runnable install path. |
 | Headless compositor path | Smoke | Build and test surfaces exist, but not re-validated in this pass. |
-| Rocky 10 package install | Smoke | Packaging exists; quickstart now documents it as a compositor/package path, not a full VR deployment. |
-| `honey` VR session | Design | `honey` has OpenXR libs and disabled Monado units, but no deployed XoxdWM stack. |
-| `yoga` desktop/dev target | Design | `yoga` is still on stock Rocky 10 and has no XoxdWM install. |
+| Rocky 10 package install | Design | The current `v0.5.0` RPM failed on `honey`: it requires bare `wayland` metadata on Rocky and ships a `/nix/store`-linked compositor binary. |
+| `honey` VR session | Design | `honey` has partial Monado/OpenXR prereqs, but no deployed XoxdWM stack or working OpenXR client-tool path. |
+| `yoga` desktop/dev target | Design | `yoga` has validated kernel work, but still has no XoxdWM userspace install. |
 | Eye tracking / hand tracking / BCI | Design | Documented and partially implemented, but not currently claimed as proven on named lab hosts. |
 
 ## Start Here
@@ -47,7 +47,7 @@ Current public install artifacts:
 - `ewwm-compositor-*.x86_64.rpm`
 - `ewwm-compositor_*_amd64.deb`
 
-These artifacts currently package the compositor path. They do not, by themselves, establish a proven full VR deployment on `honey` or `yoga`.
+These artifacts currently package the compositor path. They do not, by themselves, establish a proven full VR deployment on `honey` or `yoga`, and the current Rocky RPM release lane still needs repair before it can be treated as a usable host install path.
 
 ## Near-Term Goal
 

--- a/docs/installation-quickstart.md
+++ b/docs/installation-quickstart.md
@@ -4,7 +4,9 @@ This quickstart is intentionally narrower than the feature inventory.
 
 - For current support claims, read [Support Matrix](support-matrix.md).
 - For the repo’s current operational status, read [Status](status.md).
-- As of 2026-04-11, the Rocky path is a compositor/package path, not a claimed full VR deployment on `honey` or `yoga`.
+- As of 2026-04-12, the Rocky path is not yet a claimed working named-host install path.
+- The current public `v0.5.0` RPM failed on `honey`: its metadata requires bare `wayland` on Rocky 10 and the packaged compositor binary points at a `/nix/store/.../ld-linux...` interpreter.
+- Until a corrected release is cut, treat the Rocky RPM section as release-surface documentation, not as a supported install path.
 
 ## NixOS (Declarative)
 
@@ -35,13 +37,18 @@ Home Manager (user config):
 
 ## Rocky Linux / Fedora (RPM)
 
-This installs the released compositor package. It does not, by itself, provision a proven full VR stack.
+This describes the released compositor package path. It does not, by itself, provision a proven full VR stack, and the current public Rocky RPM still needs a packaging fix before it is a usable host install path.
 
 Download from GitHub Releases:
 ```bash
 curl -LO https://github.com/Jesssullivan/XoxdWM/releases/latest/download/ewwm-compositor-*.x86_64.rpm
 sudo dnf install ./ewwm-compositor-*.x86_64.rpm
 ```
+
+Current status:
+
+- `v0.5.0` RPM publication exists, but failed on `honey` in this audit.
+- A corrected native Rocky RPM or a validated source-build path is still required before this section can be promoted beyond `Design`.
 
 Install Emacs and enable the session:
 ```bash

--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -33,9 +33,11 @@ Current reality:
 
 - `yoga` has a validated one-time `kernel-xr` boot path.
 - `yoga` still has no installed Monado/OpenXR/XoxdWM userspace stack.
+- the current public `v0.5.0` Rocky RPM is not yet a usable named-host install path
 
 Acceptance:
 
+- a corrected native RPM or documented source-build path exists for Rocky 10
 - `yoga` can install the public package or build from source with documented steps
 - compositor launch path is documented and repeatable
 - rollback path is documented if package install fails

--- a/docs/status.md
+++ b/docs/status.md
@@ -6,6 +6,7 @@ Snapshot date: 2026-04-12
 
 - The repo has a real public release and substantial packaging work.
 - The repo now has a root README and status surface, but the named-host runtime reality still trails the packaging story.
+- The current public Rocky RPM failed on `honey`: package metadata requires bare `wayland`, and the installed compositor binary points at a `/nix/store/.../ld-linux...` interpreter.
 - `honey` is not currently running a deployed XoxdWM stack.
 - `honey` now has a proven `linux-xr` kernel default and a one-time verified PREEMPT_RT boot, but the VR userspace is still incomplete.
 - `honey` has partial XR prereqs only: `openxr-libs`, `openxr-devel`, `wlroots`, `wlroots-devel`, `/usr/local/bin/monado-service`, and `/usr/local/share/openxr/1/openxr_monado.json`.
@@ -37,7 +38,7 @@ Snapshot date: 2026-04-12
 
 ## Immediate Priorities
 
-1. Put a real XoxdWM/Monado/OpenXR client-tool install path on `honey`, not just a bare Monado runtime manifest.
-2. Produce the first named-host compositor startup on either `honey` or `yoga`.
-3. Produce one reproducible Rocky 10 XR userspace install on `yoga`.
-4. Keep the public docs honest and CI aligned with the current repo runner scope.
+1. Repair the public Rocky RPM release path so it ships a host-runnable native compositor binary and correct dependency metadata.
+2. Put a real XoxdWM/Monado/OpenXR client-tool install path on `honey`, not just a bare Monado runtime manifest.
+3. Produce the first named-host compositor startup on either `honey` or `yoga`.
+4. Produce one reproducible Rocky 10 XR userspace install on `yoga`.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -28,10 +28,10 @@ Date baseline: 2026-04-12.
 
 | Surface | Status | Notes |
 | --- | --- | --- |
-| GitHub release RPM | Smoke | Public release exists and ships `ewwm-compositor`. |
+| GitHub release RPM | Design | Public release exists, but the current `v0.5.0` Rocky RPM failed on `honey`: it depends on bare `wayland` and ships a `/nix/store`-linked compositor binary. |
 | GitHub release DEB | Smoke | Public release exists. |
 | Nix flake outputs | Smoke | Build surfaces exist; critical push CI is not green yet. |
-| Rocky 10 quickstart | Smoke | Documented as compositor/package path only. |
+| Rocky 10 quickstart | Design | Keep as packaging guidance only until a corrected native RPM or validated source-build path succeeds on a named Rocky host. |
 | NixOS / Home Manager module | Smoke | Present in repo, but not claimed as proven in this audit. |
 
 ## Runtime Areas


### PR DESCRIPTION
## Summary
- document that the current Rocky RPM release path is not yet a usable named-host install path
- record the concrete honey findings: bare wayland dependency metadata and a /nix/store-linked compositor binary
- add a packaging workflow validation gate that rejects Nix-linked RPM binaries and the bad bare wayland requirement

## Validation
- audited the published v0.5.0 RPM on honey
- verified git diff --check
- parsed .github/workflows/packaging.yml successfully