### PR TITLE
Allow manual dispatch of multi-arch workflow

### DIFF
--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -1,6 +1,7 @@
 name: Multi-Architecture Build & Test
 
 on:
+  workflow_dispatch:
   push:
     branches: [main, dev, 'feature/*']
     paths:


### PR DESCRIPTION
## Summary
- add workflow_dispatch to the multi-arch workflow
- let maintainers rerun the multi-architecture check path without pushing a no-op commit

## Why
The release PR hit a stale GitHub-hosted aarch64 job and GitHub refused the normal rerun path. This follow-up keeps that recovery path available without changing product code.