### PR TITLE
Harden yoga local session launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This repository is the canonical public home for the compositor, packaging, rele
 
 ## Current State
 
-As of 2026-04-12:
+As of 2026-04-13:
 
 | Area | Status | Notes |
 | --- | --- | --- |
-| Release artifacts | Smoke | `v0.5.0` publishes RPM and DEB artifacts, but the Rocky RPM is not yet a proven host-runnable install path. |
+| Release artifacts | Smoke | `v0.5.1` publishes RPM and DEB artifacts. The Rocky base compositor RPM is now public and host-installable. |
 | Headless compositor path | Smoke | Build and test surfaces exist, but not re-validated in this pass. |
-| Rocky 10 package install | Design | The current public `v0.5.0` RPM failed on `honey`: it requires bare `wayland` metadata on Rocky and ships a `/nix/store`-linked compositor binary. The active `0.5.1` repair lane is targeting a native non-`vr` compositor RPM first, with SELinux hardening and the BrainFlow BCI virtualenv treated as separate follow-on package concerns rather than release gates. |
+| Rocky 10 package install | Smoke | `v0.5.1` ships a native non-`vr` compositor RPM. `yoga` validated package install, clean runtime linking, and bounded compositor startup. Local session ergonomics are still follow-on work. |
 | `honey` VR session | Design | `honey` has partial Monado/OpenXR prereqs, but no deployed XoxdWM stack or working OpenXR client-tool path. |
-| `yoga` desktop/dev target | Design | `yoga` has validated kernel work, but still has no XoxdWM userspace install. |
+| `yoga` desktop/dev target | Smoke | `yoga` now has the released Rocky package installed and a named-host bounded compositor result, but not yet a polished local login/session path. |
 | Eye tracking / hand tracking / BCI | Design | Documented and partially implemented, but not currently claimed as proven on named lab hosts. |
 
 ## Start Here
@@ -41,13 +41,14 @@ Only the support matrix and status docs should be read as the current operationa
 Latest public release:
 
 - [`v0.5.0`](https://github.com/Jesssullivan/XoxdWM/releases/tag/v0.5.0)
+- [`v0.5.1`](https://github.com/Jesssullivan/XoxdWM/releases/tag/v0.5.1)
 
 Current public install artifacts:
 
 - `exwm-vr-compositor-*.x86_64.rpm`
 - `ewwm-compositor_*_amd64.deb`
 
-These artifacts currently package the compositor path. They do not, by themselves, establish a proven full VR deployment on `honey` or `yoga`, and the Rocky RPM release lane is being repaired as a native non-`vr` compositor package before any full VR claim is made. SELinux hardening and the BrainFlow BCI virtualenv are being tracked as separate opt-in package paths instead of blocking the base Rocky compositor release.
+These artifacts currently package the compositor path. They do not, by themselves, establish a proven full VR deployment on `honey`, and they do not yet mean `yoga` has a polished local login/session experience. SELinux hardening, Monado integration, and the BrainFlow BCI virtualenv remain separate follow-on package or host-integration paths instead of blocking the base Rocky compositor release.
 
 ## Near-Term Goal
 

--- a/docs/installation-quickstart.md
+++ b/docs/installation-quickstart.md
@@ -4,11 +4,11 @@ This quickstart is intentionally narrower than the feature inventory.
 
 - For current support claims, read [Support Matrix](support-matrix.md).
 - For the repo’s current operational status, read [Status](status.md).
-- As of 2026-04-12, the Rocky path is not yet a claimed working named-host install path.
-- The current public `v0.5.0` RPM failed on `honey`: its metadata requires bare `wayland` on Rocky 10 and the packaged compositor binary points at a `/nix/store/.../ld-linux...` interpreter.
-- Until a corrected release is cut, treat the Rocky RPM section as release-surface documentation, not as a supported install path.
-- The active `0.5.1` repair lane is targeting a native Rocky compositor RPM without the `vr` Cargo feature; Monado integration and full VR enablement remain separate source/Nix or follow-on packaging work for now.
-- The same repair lane now treats SELinux hardening and the BrainFlow BCI virtualenv as separate opt-in package concerns so the base Rocky compositor RPM is not blocked on those follow-on paths.
+- As of 2026-04-13, the Rocky base compositor package lane is public in `v0.5.1`.
+- `yoga` validated the Rocky RPM install path: the compositor package installs, links cleanly on-host, and can be started in a bounded named-host run with `seatd`.
+- The remaining Rocky follow-on is local session ergonomics on `yoga`, not the base RPM artifact itself.
+- Monado integration and full VR enablement remain separate follow-on work after the base Rocky compositor package path.
+- SELinux hardening and the BrainFlow BCI virtualenv remain separate opt-in package concerns so the base Rocky compositor RPM stays shippable.
 
 ## NixOS (Declarative)
 
@@ -39,7 +39,7 @@ Home Manager (user config):
 
 ## Rocky Linux / Fedora (RPM)
 
-This describes the released compositor package path. It does not, by itself, provision a proven full VR stack, and the current public Rocky RPM still needs a packaging fix before it is a usable host install path. The repair lane is currently converging on a native non-`vr` compositor RPM first, with SELinux policy packaging and the BrainFlow BCI virtualenv treated as separate follow-on paths.
+This describes the released compositor package path. It does not, by itself, provision a full VR stack. The current public Rocky release is the native non-`vr` compositor package path; SELinux policy packaging, Monado integration, and the BrainFlow BCI virtualenv remain separate follow-on paths.
 
 Download from GitHub Releases:
 ```bash
@@ -49,15 +49,19 @@ sudo dnf install ./exwm-vr-compositor-*.x86_64.rpm
 
 Current status:
 
-- `v0.5.0` RPM publication exists, but failed on `honey` in this audit.
-- A corrected native Rocky RPM or a validated source-build path is still required before this section can be promoted beyond `Design`.
-- Full VR/OpenXR enablement on Rocky is still a separate follow-on step after the native compositor RPM works on a named host.
-- SELinux policy packaging and the BrainFlow BCI virtualenv are separate follow-on steps after the base compositor RPM works on a named host.
+- `v0.5.1` is public and ships the corrected native Rocky compositor RPM.
+- `yoga` validated package install and bounded runtime on Rocky 10.
+- A polished local login/session path on `yoga` is still follow-on work after the base package lane.
+- Full VR/OpenXR enablement on Rocky is still a separate follow-on step after the base compositor package path.
+- SELinux policy packaging and the BrainFlow BCI virtualenv are separate follow-on steps after the base compositor package path.
 
 Install Emacs and enable the session:
 ```bash
-sudo dnf install emacs
-# Log out, select "EXWM-VR" session at login screen if the session file is installed
+sudo dnf install emacs dbus-daemon seatd xorg-x11-server-Xwayland
+sudo systemctl enable --now seatd
+sudo usermod -aG seat "$USER"
+# Log out and back in so the seat group reaches the local session/user manager.
+# The display-manager or local-launch path is still being hardened on yoga.
 ```
 
 ## Debian / Ubuntu (DEB)
@@ -111,5 +115,5 @@ emacs --batch -L lisp/core -L lisp/vr -L lisp/ext -l test/run-tests.el
 
 ## Named-Host Guidance
 
-- `yoga`: target desktop/dev host for the next reproducible Rocky 10 install path.
+- `yoga`: Rocky 10 package install is validated; local session ergonomics are the active follow-on.
 - `honey`: target VR smoke host, but not currently documented here as a proven XoxdWM deployment.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,20 +1,20 @@
 # XoxdWM Status
 
-Snapshot date: 2026-04-12
+Snapshot date: 2026-04-13
 
 ## Honest Assessment
 
 - The repo has a real public release and substantial packaging work.
-- The repo now has a root README and status surface, but the named-host runtime reality still trails the packaging story.
-- The current public Rocky RPM failed on `honey`: package metadata requires bare `wayland`, and the installed compositor binary points at a `/nix/store/.../ld-linux...` interpreter.
-- The active `0.5.1` repair lane is now building toward a native Rocky compositor RPM without the `vr` Cargo feature; full VR packaging is still blocked on a real `libuvc` path.
-- The latest native Rocky RPM blocker is no longer the compositor build itself. The repair lane now treats Monado integration, SELinux hardening, and the BrainFlow BCI virtualenv as separate opt-in package paths so the base Rocky compositor RPM can be proven first.
+- `v0.5.1` is publicly released and publishes the repaired Rocky compositor RPM and the DEB artifact.
+- The base Rocky RPM gate is complete: the public package now installs on Rocky 10 without the earlier bare-`wayland` metadata or `/nix/store` runtime-linking problems.
+- The release lane now treats Monado integration, SELinux hardening, and the BrainFlow BCI virtualenv as separate opt-in package paths so the base Rocky compositor package can stay shippable.
 - `honey` is not currently running a deployed XoxdWM stack.
 - `honey` now has a proven `linux-xr` kernel default and a one-time verified PREEMPT_RT boot, but the VR userspace is still incomplete.
 - `honey` has partial XR prereqs only: `openxr-libs`, `openxr-devel`, `wlroots`, `wlroots-devel`, `/usr/local/bin/monado-service`, and `/usr/local/share/openxr/1/openxr_monado.json`.
 - `honey` does not currently expose `openxr-info`, `xrgears`, or `xoxdwm`, and no active DRM connector or obvious HMD path was present during the audit.
-- `yoga` is not currently running a deployed XoxdWM stack.
-- `yoga` now has a one-time validated `kernel-xr` boot path, but stock Rocky remains the persistent default and no XR userspace stack is installed.
+- `yoga` now has the public Rocky package installed: `exwm-vr`, `exwm-vr-compositor`, and `exwm-vr-elisp`.
+- `yoga` validated the named-host package line: the compositor binary links cleanly, a bounded runtime succeeds with `seatd`, and Wayland/DRM/libinput startup is confirmed.
+- `yoga` still does not have a polished local login/session path. The remaining follow-on is session ergonomics: display-manager or local-launch flow, seat backend propagation into user services, and a fresh-login/user-manager path after seat-group changes.
 - Recent push CI failures were concentrated in three places:
   - Rocky test: optional `sccache` setup step
   - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
@@ -30,17 +30,19 @@ Snapshot date: 2026-04-12
 - publishing experimental package artifacts
 - carrying the userspace side of Rocky 10 / Wayland / VR integration work
 - serving as the research and implementation repo for the `honey` and `yoga` MVP paths now that both hosts have validated kernel lanes
+- carrying a real public Rocky compositor package that has been validated on `yoga`
 
 ## What This Repo Is Not Claiming Right Now
 
 - daily-driver VR on `honey`
 - a complete turnkey Rocky 10 VR deployment
-- a working named-host XoxdWM compositor install on `honey` or `yoga`
+- a polished local login/session launch on `yoga`
+- a working named-host XoxdWM compositor install on `honey`
 - proven eye tracking, hand tracking, or BCI support on current named lab hosts
 
 ## Immediate Priorities
 
-1. Finish the corrected public Rocky RPM release path so it ships a host-runnable native compositor binary and correct dependency metadata, without making SELinux policy compilation or the BrainFlow BCI virtualenv a release gate.
+1. Finish the local login/session path on `yoga` so the named-host result is not limited to a bounded ssh-driven compositor smoke.
 2. Put a real XoxdWM/Monado/OpenXR client-tool install path on `honey`, not just a bare Monado runtime manifest.
-3. Produce the first named-host compositor startup on either `honey` or `yoga`.
-4. Produce one reproducible Rocky 10 XR userspace install on `yoga`.
+3. Produce the first named-host compositor startup on `honey`.
+4. Keep the Rocky base package lane green while leaving Monado, SELinux, and BCI as separate follow-on concerns.

--- a/packaging/desktop/exwm-vr-session
+++ b/packaging/desktop/exwm-vr-session
@@ -26,6 +26,14 @@ export ELECTRON_OZONE_PLATFORM_HINT=auto
 export XCURSOR_THEME="${XCURSOR_THEME:-Adwaita}"
 export XCURSOR_SIZE="${XCURSOR_SIZE:-24}"
 
+# ── Seat backend ──────────────────────────────────────────────────────
+# On Rocky hosts we validate the named-host launch path with seatd. When the
+# seatd socket exists and no explicit backend was provided, prefer that backend
+# so systemd user services inherit the same working seat setup as direct runs.
+if [ -z "${LIBSEAT_BACKEND:-}" ] && [ -S /run/seatd.sock ]; then
+    export LIBSEAT_BACKEND=seatd
+fi
+
 # ── XDG portal config ────────────────────────────────────────────────
 # Point portal backends at our config (screencopy, file chooser, etc.)
 if [ -f /usr/share/xdg-desktop-portal/exwm-vr-portals.conf ]; then
@@ -54,12 +62,58 @@ fi
 
 # ── Systemd path ─────────────────────────────────────────────────────
 if command -v systemctl >/dev/null 2>&1 && systemctl --user list-unit-files exwm-vr.target >/dev/null 2>&1; then
+    # Import the session environment into the user manager before starting the
+    # target so compositor/user services inherit the same runtime context as
+    # the launcher.
+    systemctl --user import-environment \
+        DBUS_SESSION_BUS_ADDRESS \
+        LIBSEAT_BACKEND \
+        WAYLAND_DISPLAY \
+        XDG_CURRENT_DESKTOP \
+        XDG_DESKTOP_PORTAL_DIR \
+        XDG_RUNTIME_DIR \
+        XDG_SESSION_DESKTOP \
+        XDG_SESSION_TYPE \
+        XR_RUNTIME_JSON \
+        QT_QPA_PLATFORM \
+        SDL_VIDEODRIVER \
+        MOZ_ENABLE_WAYLAND \
+        _JAVA_AWT_WM_NONREPARENTING \
+        CLUTTER_BACKEND \
+        ECORE_EVAS_ENGINE \
+        ELM_ENGINE \
+        GDK_BACKEND \
+        ELECTRON_OZONE_PLATFORM_HINT \
+        XCURSOR_THEME \
+        XCURSOR_SIZE >/dev/null 2>&1 || true
+
     echo "Starting EXWM-VR via systemd user target..."
     systemctl --user start exwm-vr.target
 
-    # Wait for the compositor to exit; when it stops the session is over.
-    # BindsTo in the emacs unit will bring everything else down.
-    exec systemctl --user --wait start exwm-vr-compositor.service
+    # Wait until the compositor reaches a stable running or failed state.
+    seen_active=0
+    while true; do
+        state="$(systemctl --user show -p ActiveState --value exwm-vr-compositor.service 2>/dev/null || echo failed)"
+        case "$state" in
+            active)
+                seen_active=1
+                ;;
+            failed)
+                echo "ERROR: exwm-vr-compositor.service failed to start" >&2
+                exec systemctl --user status exwm-vr-compositor.service --no-pager -l
+                ;;
+            inactive)
+                if [ "$seen_active" -eq 1 ]; then
+                    break
+                fi
+                ;;
+        esac
+        sleep 1
+    done
+
+    # Once the compositor has run, bring the session target down cleanly.
+    systemctl --user stop exwm-vr.target >/dev/null 2>&1 || true
+    exit 0
 fi
 
 # ── Fallback: direct launch ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- prefer seatd automatically when its socket is present
- import session environment into the systemd user manager before starting the EXWM-VR target
- keep the session wrapper attached to compositor service lifetime instead of returning as soon as the start job completes
- update the README and status/quickstart docs to reflect the real post-v0.5.1 Rocky and yoga state

## Why
On yoga, the public v0.5.1 package line is validated, but the local session path still had two concrete gaps:
- the systemd-user launch path did not propagate the working seat backend into the compositor service
- the session wrapper did not actually stay attached to compositor lifetime in the systemd path

This follow-up keeps the Rocky package release claim honest while moving yoga from bounded smoke toward a repeatable local launch path.

## Validation
- bash -n packaging/desktop/exwm-vr-session
- git diff --check
- yoga host checks after installing dbus-daemon and Xwayland
- bounded wrapper test and user-unit log inspection on yoga