### PR TITLE
Stamp release version into build inputs

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,7 +8,6 @@ on:
       version:
         description: 'Package version (without v prefix)'
         required: true
-        default: '0.5.1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +23,19 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stamp release version
+        run: |
+          python3 scripts/stamp-release-version.py "${{ steps.version.outputs.version }}"
 
       - uses: cachix/install-nix-action@v30
       - uses: ryanccn/attic-action@v0
@@ -76,6 +88,10 @@ jobs:
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Stamp release version
+        run: |
+          python3 scripts/stamp-release-version.py "${{ steps.version.outputs.version }}"
 
       - name: Generate vendored cargo tarball
         run: |

--- a/compositor/Cargo.lock
+++ b/compositor/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "ewwm-compositor"
-version = "0.5.1"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",

--- a/compositor/Cargo.toml
+++ b/compositor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ewwm-compositor"
-version = "0.5.1"
+version = "0.5.3"
 edition = "2021"
 publish = false
 description = "EXWM-VR Wayland compositor built on Smithay"

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
   outputs = { self, nixpkgs, emacs-overlay, rust-overlay, flake-utils, nix2container, home-manager, nixpkgs-xr }:
     let
-      version = "0.5.1";
+      version = "0.5.3";
 
       # XR kernel module — patches + structured config for Bigscreen Beyond 2e
       xrKernelLib = import ./nix/kernel/xr-kernel.nix;

--- a/scripts/stamp-release-version.py
+++ b/scripts/stamp-release-version.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def rewrite(path: Path, pattern: str, replacement: str, *, count: int = 1) -> None:
+    content = path.read_text()
+    updated, matches = re.subn(pattern, replacement, content, count=count, flags=re.MULTILINE)
+    if matches == 0:
+        raise SystemExit(f"failed to stamp version in {path}")
+    path.write_text(updated)
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: stamp-release-version.py <version>")
+
+    version = sys.argv[1]
+    root = Path(__file__).resolve().parents[1]
+
+    rewrite(root / "flake.nix", r'version = "[^"]+";', f'version = "{version}";')
+    rewrite(root / "compositor" / "Cargo.toml", r'^version = "[^"]+"$', f'version = "{version}"')
+    rewrite(
+        root / "compositor" / "Cargo.lock",
+        r'(name = "ewwm-compositor"\nversion = ")[^"]+(")',
+        rf'\g<1>{version}\2',
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
The  RPM/DEB release published correctly, but the shipped compositor binary on yoga still self-reports . The release workflow was only stamping package metadata; the actual build inputs ( and ) were still stale.

## What changed
- add  to stamp the requested release version into , , and the  package entry in 
- run that helper before the Nix binary build and before the RPM source/vendoring path
- remove the misleading  default version so manual release validation must pass an explicit version
- bump the checked-in base version literals from  to 

## Validation
- 
- 
- confirmed the published  yoga binary reports , which this fix addresses for future releases