### PR TITLE
feat(greptile): add review configuration and coding standards

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,27 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "ignorePatterns": "build/**\n*.o\n*.d\n*.a\n*.so\n*.dylib\ntarget/**\nCargo.lock",
+  "statusCheck": true,
+  "fixWithAI": true,
+  "shouldUpdateDescription": true,
+  "summarySection": { "included": true, "collapsible": false, "defaultOpen": true },
+  "issuesTableSection": { "included": true, "collapsible": true, "defaultOpen": true },
+  "sequenceDiagramSection": { "included": false, "collapsible": true, "defaultOpen": false },
+  "instructions": "Window manager project. Review for memory safety, correct event handling, and proper resource cleanup. Flag any unbounded allocations or missing error checks on system calls.",
+  "patternRepositories": [],
+  "customContext": {
+    "rules": [
+      "All system call return values must be checked",
+      "Memory allocations must have corresponding free/dealloc on all code paths",
+      "If Rust: unsafe blocks require SAFETY comments",
+      "If C: no implicit fallthrough in switch statements without comment",
+      "Event loop must not block on I/O without timeout"
+    ],
+    "files": [
+      { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] }
+    ]
+  }
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,3 @@
+[
+  { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] }
+]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,28 @@
+# XoxdWM: Repo-Specific Review Rules
+
+Inherits all rules from `_org-enforced-rules.md`.
+
+## Systems Programming
+
+- All system call return values must be checked. No ignoring `errno`.
+- Memory allocations must have corresponding cleanup on all code paths, including error paths.
+- No unbounded stack allocations (e.g., VLAs or large arrays on stack).
+
+## If C
+
+- No implicit fallthrough in `switch` without a `/* fallthrough */` comment.
+- Use `const` on pointers that should not be modified.
+- Header files must have include guards (`#ifndef`/`#define`/`#endif`).
+- Prefer `size_t` for sizes and indices.
+
+## If Rust
+
+- `unsafe` blocks require `// SAFETY:` comments.
+- No `unwrap()` in event handling code paths -- use proper error handling.
+- Use `#[deny(unsafe_op_in_unsafe_fn)]` at the crate level.
+
+## Window Management
+
+- Event loop must not block indefinitely without a timeout or signal mechanism.
+- Resource handles (windows, display connections) must be released on shutdown.
+- Configuration parsing must handle malformed input gracefully, not panic.


### PR DESCRIPTION
Adds .greptile/ configuration folder with:
- config.json: review behavior, C/Rust dual-language settings
- rules.md: memory safety, syscall handling, event loop standards
- files.json: reference to CLAUDE.md for context

Part of Greptile Phase 1 rollout (TIN-58).