### PR TITLE
ci: align shared runner contract

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -7,24 +7,26 @@ on:
 
 jobs:
   warm-nix-cache:
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED != 'true'
         uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
 
       - name: Setup Attic
         if: env.ATTIC_SERVER != ''
         uses: ryanccn/attic-action@v0
         with:
-          endpoint: ${{ secrets.ATTIC_SERVER }}
-          cache: ${{ secrets.ATTIC_CACHE }}
+          endpoint: ${{ env.ATTIC_SERVER }}
+          cache: ${{ env.ATTIC_CACHE }}
           token: ${{ secrets.ATTIC_TOKEN }}
 
       - name: Build x86_64 packages
@@ -58,7 +60,7 @@ jobs:
           done
 
       - name: Build cross targets
-        if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED == 'true'
         run: |
           echo "=== Cross-building aarch64 compositor ==="
           nix build .#packages.aarch64-linux.compositor --out-link result-aarch64 || true
@@ -70,7 +72,7 @@ jobs:
           nix build .#packages.s390x-linux.compositor-headless --out-link result-s390x || true
 
       - name: Push cross targets to Attic
-        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true'
         run: |
           for link in result-aarch64 result-aarch64-headless result-s390x; do
             if [ -L "$link" ]; then

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -28,12 +28,13 @@ concurrency:
 jobs:
   build-x86_64:
     name: Build x86_64 (full + VR)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -61,12 +62,13 @@ jobs:
 
   build-headless:
     name: Build x86_64 (headless)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -91,12 +93,13 @@ jobs:
 
   ert-tests:
     name: ERT Tests
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -114,13 +117,14 @@ jobs:
 
   cross-aarch64:
     name: Cross-compile aarch64
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -137,12 +141,13 @@ jobs:
 
   cross-s390x:
     name: Cross-compile s390x
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -32,12 +32,13 @@ jobs:
   # ── Nix build (self-hosted) ──────────────────────────────
   nix-build:
     name: Nix Build (wlroots + sway)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -20,14 +20,15 @@ concurrency:
 jobs:
   build:
     name: Nix Build
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED != 'true'
         uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - name: Verify Nix
         run: nix --version
       - uses: ryanccn/attic-action@v0

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-binary:
     name: Build Compositor Binary
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +38,7 @@ jobs:
           python3 scripts/stamp-release-version.py "${{ steps.version.outputs.version }}"
 
       - uses: cachix/install-nix-action@v30
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -13,12 +13,13 @@ concurrency:
 jobs:
   nix-runner:
     name: Nix Runner Health
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   fast-check:
     name: Fast Check (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   fast-build:
     name: Fast Build (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Summary
- remove stable shared-runner jobs from the repo-specific tinyland-inc/XoxdWM guard
- use tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main in the stable cache-consuming workflows
- leave the hardware-only compatibility jobs unchanged

Notes
- this is the tranche-1 user-owned canary from tinyland-inc/GloriousFlywheel#210
- hardware-specific flows remain intentionally out of scope

Validation
- git diff --check passed locally