### PR TITLE
[codex] ci: remove fork gate from shared self hosted paths

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   warm-nix-cache:
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED != 'true'
         uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -58,7 +58,7 @@ jobs:
           done
 
       - name: Build cross targets
-        if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED == 'true'
         run: |
           echo "=== Cross-building aarch64 compositor ==="
           nix build .#packages.aarch64-linux.compositor --out-link result-aarch64 || true
@@ -70,7 +70,7 @@ jobs:
           nix build .#packages.s390x-linux.compositor-headless --out-link result-s390x || true
 
       - name: Push cross targets to Attic
-        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+        if: env.ATTIC_SERVER != '' && vars.USE_SELFHOSTED == 'true'
         run: |
           for link in result-aarch64 result-aarch64-headless result-s390x; do
             if [ -L "$link" ]; then

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build-x86_64:
     name: Build x86_64 (full + VR)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
   build-headless:
     name: Build x86_64 (headless)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
 
   ert-tests:
     name: ERT Tests
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
 
   cross-aarch64:
     name: Cross-compile aarch64
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     continue-on-error: true
     steps:
@@ -137,7 +137,7 @@ jobs:
 
   cross-s390x:
     name: Cross-compile s390x
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -32,7 +32,7 @@ jobs:
   # ── Nix build (self-hosted) ──────────────────────────────
   nix-build:
     name: Nix Build (wlroots + sway)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -20,13 +20,13 @@ concurrency:
 jobs:
   build:
     name: Nix Build
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true' || github.repository != 'tinyland-inc/XoxdWM'
+        if: vars.USE_SELFHOSTED != 'true'
         uses: cachix/install-nix-action@v30
       - name: Verify Nix
         run: nix --version

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-binary:
     name: Build Compositor Binary
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   nix-runner:
     name: Nix Runner Health
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   fast-check:
     name: Fast Check (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
@@ -96,7 +96,7 @@ jobs:
 
   fast-build:
     name: Fast Build (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true'
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -38,7 +38,7 @@ jobs:
   fast-check:
     name: Fast Check (self-hosted)
     if: vars.USE_SELFHOSTED == 'true'
-    runs-on: tinyland-nix
+    runs-on: xoxdwm-nix
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
   fast-build:
     name: Fast Build (self-hosted)
     if: vars.USE_SELFHOSTED == 'true'
-    runs-on: tinyland-nix
+    runs-on: xoxdwm-nix
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed

This removes the fork-only repository gate from the shared self-hosted workflow paths in the Jess repo:
- `self-hosted-fast.yml`
- `cache-warm.yml`
- `native-deps.yml`
- `multi-arch.yml`
- `nix-cache.yml`
- `packaging.yml`
- `runner-health.yml`

The raw hardware-specific paths remain gated and unchanged.

## Why it changed

The repo shared self-hosted contract was fork-shaped.

`Jesssullivan/XoxdWM` is the non-fork repo that would be counted in orgwide adoption reads, but the self-hosted fast path only activated for `tinyland-inc/XoxdWM`. That made the main downstream metric depend on a fork exception.

## Important behavior note

This repo now already has `USE_SELFHOSTED=true`.

That means this PR is not inert. On the Jess repo it exposes the real next blocker: the repo currently reports `0` accessible Actions runners, so the shared `tinyland-nix` jobs queue without capacity unless runner access is restored or the toggle is turned back off.

## Impact

After runner inventory is restored, the Jess repo can become the real shared-runner authority surface without depending on the fork-specific repository check.

Until then, this PR should stay draft because it makes the activation mismatch visible rather than solving it by itself.

## Validation

- `git diff --check`
- YAML parse of `.github/workflows/*.yml`
- remaining `tinyland-inc/XoxdWM` gates verified to be hardware-specific only
- live repo inspection confirmed `USE_SELFHOSTED=true` and `0` accessible runners on the Jess repo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `github.repository == 'tinyland-inc/XoxdWM'` fork gate from seven shared self-hosted workflow paths, making `jesssullivan/xoxdwm` eligible to use the `tinyland-nix` runner fleet when `USE_SELFHOSTED=true`. The PR is intentionally a draft since the Jess repo currently reports 0 accessible runners, so all gated jobs will queue without capacity until that is resolved.

- `self-hosted-fast.yml` changes the runner label to `xoxdwm-nix` for `fast-check`/`fast-build`, while all other six workflows still target `tinyland-nix` — if runners are only registered under one label, the `self-hosted-fast` jobs and the rest of the fleet will silently diverge.

<h3>Confidence Score: 4/5</h3>

Safe to keep as draft; the runner label split in self-hosted-fast.yml should be resolved before promoting to ready

All six support workflows are clean mechanical removals of the fork check. The one P1 finding is the `xoxdwm-nix` vs `tinyland-nix` label split in `self-hosted-fast.yml`, which will cause those jobs to queue on a different (possibly unregistered) runner label once runners are restored.

.github/workflows/self-hosted-fast.yml — runner label (`xoxdwm-nix`) is inconsistent with the `tinyland-nix` label used in all other updated workflows

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/self-hosted-fast.yml | Removes fork gate from `fast-check`/`fast-build` and renames their runner label from `tinyland-nix` to `xoxdwm-nix`, while the other 6 workflows still target `tinyland-nix` — a split that will cause jobs to queue on different (potentially non-existent) runners |
| .github/workflows/cache-warm.yml | Removes fork gate from runner selection and self-hosted-only build steps; `Install Nix` skip condition correctly simplified to `USE_SELFHOSTED != 'true'` |
| .github/workflows/multi-arch.yml | Removes fork gate from five `runs-on` ternaries; straightforward mechanical change, no logic issues |
| .github/workflows/native-deps.yml | Single `runs-on` ternary simplified by dropping the fork check; change is clean |
| .github/workflows/nix-cache.yml | Fork gate removed from both `runs-on` and `Install Nix` conditions; consistent with cache-warm.yml treatment |
| .github/workflows/packaging.yml | Single `runs-on` ternary simplified; no issues |
| .github/workflows/runner-health.yml | Single `runs-on` ternary simplified; no issues |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/self-hosted-fast.yml
Line: 41

Comment:
**Runner label mismatch with other workflows**

`self-hosted-fast.yml` now targets `xoxdwm-nix`, but all six other workflows updated in this PR (`cache-warm.yml`, `multi-arch.yml`, `native-deps.yml`, `nix-cache.yml`, `packaging.yml`, `runner-health.yml`) still route to `tinyland-nix`. Unless both labels are registered on the same runner, `fast-check` and `fast-build` will queue separately from the rest of the self-hosted fleet and likely never pick up if only `tinyland-nix`-labeled runners are provisioned.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: target repo scoped xoxdwm nix lane"](https://github.com/jesssullivan/xoxdwm/commit/975bcdd18791700b78d9d4be3d74f8a0dd6c7bdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28918370)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->