### PR TITLE
[codex] ci: gate Honey hardware lanes explicitly

### DIFF
--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -61,7 +61,7 @@ jobs:
     name: VR Runner Health
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true'
     steps:
       - name: Runner info
         run: |

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -138,7 +138,9 @@ jobs:
 
   fast-vr:
     name: Fast VR Smoke (self-hosted)
-    if: vars.USE_SELFHOSTED == 'true' && github.repository == 'tinyland-inc/XoxdWM'
+    # Hardware-in-the-loop smoke is opt-in and should follow runner capability,
+    # not which repo name happened to own the lane historically.
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true'
     needs: fast-build
     runs-on: [self-hosted, honey]
     timeout-minutes: 10

--- a/.github/workflows/vr-hardware.yml
+++ b/.github/workflows/vr-hardware.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   preflight:
     name: Hardware Preflight
-    if: github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true'
     runs-on: [self-hosted, honey]
     timeout-minutes: 5
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   compositor-gpu:
     name: Compositor GPU Build & Test
-    if: github.repository == 'tinyland-inc/XoxdWM'
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true'
     needs: preflight
     runs-on: [self-hosted, honey]
     timeout-minutes: 30
@@ -86,7 +86,7 @@ jobs:
 
   vr-session:
     name: VR Session Lifecycle
-    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
@@ -125,7 +125,7 @@ jobs:
 
   drm-lease:
     name: DRM Lease Detection
-    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite != 'smoke' || github.ref_type == 'tag')
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true' && (inputs.test-suite != 'smoke' || github.ref_type == 'tag')
     needs: preflight
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
@@ -160,7 +160,7 @@ jobs:
 
   eye-tracking:
     name: Eye Tracking E2E
-    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
@@ -203,7 +203,7 @@ jobs:
 
   benchmark:
     name: GPU Benchmark
-    if: github.repository == 'tinyland-inc/XoxdWM' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
+    if: vars.USE_SELFHOSTED == 'true' && vars.USE_VR_HARDWARE == 'true' && (inputs.test-suite == 'full' || github.ref_type == 'tag')
     needs: compositor-gpu
     runs-on: [self-hosted, honey]
     timeout-minutes: 20

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is the canonical public home for the compositor, packaging, rele
 
 ## Current State
 
-As of 2026-04-13:
+As of 2026-04-19:
 
 | Area | Status | Notes |
 | --- | --- | --- |
@@ -35,6 +35,8 @@ The repo contains four different kinds of work:
 - aspirational feature inventory
 
 Only the support matrix and status docs should be read as the current operational truth.
+
+Shared self-hosted CI now runs from this canonical repo. Honey-backed hardware lanes remain explicit opt-in via `USE_VR_HARDWARE` rather than implicit fork-only behavior.
 
 ## Releases
 

--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -23,7 +23,8 @@ Acceptance:
 - Rocky test no longer fails in optional cache setup
 - self-hosted Nix workflows stop reinstalling Nix on provisioned runners
 - weekly runner-health remains available without dominating repo signal
-- self-hosted jobs do not target unavailable `tinyland-inc/XoxdWM` runner scope from the current `Jesssullivan/XoxdWM` repo
+- shared self-hosted jobs run from `Jesssullivan/XoxdWM` without fork-specific repo-name gates
+- Honey / VR hardware lanes use explicit `USE_VR_HARDWARE` opt-in instead of repo-name policy
 
 ## Epic 3: Rocky 10 Desktop/Dev MVP On `yoga`
 
@@ -51,6 +52,7 @@ Current reality:
 
 - `honey` has a proven generic `linux-xr` default and a one-time verified RT lane.
 - `honey` has a Monado runtime manifest and `monado-service`, but not the OpenXR client tooling or compositor deployment needed for a real smoke path.
+- the Honey-backed workflows are now capability-gated, but the canonical repo is still not claiming an always-on hardware runner surface by default
 
 Acceptance:
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # XoxdWM Status
 
-Snapshot date: 2026-04-13
+Snapshot date: 2026-04-19
 
 ## Honest Assessment
 
@@ -19,10 +19,10 @@ Snapshot date: 2026-04-13
   - Rocky test: optional `sccache` setup step
   - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
   - self-hosted fast CI: heavy checks on all pushes, including non-code work
-- Current self-hosted runner scope does not match the current public repo:
-  - historical self-hosted evidence on `honey` points at `tinyland-inc/XoxdWM`
-  - live runners we found are registered to `tinyland-inc`, `Jesssullivan/cmux`, `Jesssullivan/outbot-ci`, and `Jesssullivan/chapel`
-  - we did not find a runner registration that can accept jobs from `Jesssullivan/XoxdWM`
+- Shared self-hosted CI now proves out on the canonical repo:
+  - `Jesssullivan/XoxdWM#29` removed the shared-path fork gate and passed on an ephemeral `xoxdwm-nix` runner
+  - the remaining Honey / VR hardware lanes now key off explicit `USE_VR_HARDWARE` opt-in instead of `github.repository == 'tinyland-inc/XoxdWM'`
+  - the repo-level Actions runners API still reports `0` accessible runners on both repos, so runner inventory is still somewhat opaque even though the live shared path works
 
 ## What This Repo Is Good For Right Now
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -8,7 +8,7 @@ Status vocabulary:
 - `Smoke`: packaged or manually validated once, but not yet a stable supported lane.
 - `Design`: code/docs/research exist, but the flow is not yet claimed as working on a named target.
 
-Date baseline: 2026-04-12.
+Date baseline: 2026-04-19.
 
 ## Named Hosts
 
@@ -53,8 +53,9 @@ Date baseline: 2026-04-12.
 | --- | --- | --- |
 | Lightweight CI on code changes | Smoke | Kept as primary CI surface. |
 | Rocky Linux test | Smoke | Workflow exists; current failure was isolated to optional `sccache` setup. |
-| Self-hosted fast CI | Smoke | Still useful, but now skips cleanly on `Jesssullivan/XoxdWM` when no matching self-hosted runner scope exists. |
-| Scheduled runner health | Smoke | Reduced to weekly to avoid daily noise dominating repo health. |
+| Self-hosted fast CI | Smoke | Shared `xoxdwm-nix` lane now runs on `Jesssullivan/XoxdWM`; repo-level runner inventory is still opaque, but the path is proven. |
+| VR hardware-in-the-loop CI | Design | Honey-backed jobs now require explicit `USE_VR_HARDWARE=true` instead of a fork-shaped repo-name gate. The lane is not yet claimed as active on the canonical repo by default. |
+| Scheduled runner health | Smoke | Reduced to weekly to avoid daily noise dominating repo health; the VR runner check is explicit opt-in. |
 
 ## Interpretation
 


### PR DESCRIPTION
## What changed

This removes the remaining VR / Honey workflow dependence on `github.repository == 'tinyland-inc/XoxdWM'` in the canonical `Jesssullivan/XoxdWM` repo.

The hardware-in-the-loop jobs now key off explicit capability flags instead:
- `vars.USE_SELFHOSTED == 'true'`
- `vars.USE_VR_HARDWARE == 'true'`

Changed workflow surfaces:
- `.github/workflows/self-hosted-fast.yml`
- `.github/workflows/runner-health.yml`
- `.github/workflows/vr-hardware.yml`

It also updates the top-level repo docs so the status, support matrix, and roadmap reflect the actual post-`#29` CI topology.

## Why it changed

The shared CI path is already canonicalized on `Jesssullivan/XoxdWM`, but the remaining Honey / VR jobs were still fork-shaped policy. They only ran because the repo name was the org fork, not because the hardware capability was intentionally enabled.

That made the last piece of the split-brain ambiguous and blocked clean lifecycle decisions around `tinyland-inc/XoxdWM`.

## Impact

After this PR:
- the canonical repo no longer encodes any active workflow dependence on the org-fork repo name
- hardware-in-the-loop VR jobs are explicit opt-in instead of implicit fork behavior
- the hardware lane can be enabled deliberately later by setting `USE_VR_HARDWARE=true` on the repo that should own it
- keeping or retiring the org fork becomes an operational decision, not a code-path dependency

## Important behavior note

This PR does **not** turn the Honey lane on by itself.

If `USE_VR_HARDWARE` is unset or false, the VR / Honey jobs stay skipped. That is intentional until runner visibility and ownership are settled cleanly.

## Validation

- `git diff --check`
- Ruby YAML parse of the edited workflow files
- repo search confirming the remaining `tinyland-inc/XoxdWM` reference is now documentation about the retired policy, not an active workflow gate

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the remaining `github.repository == 'tinyland-inc/XoxdWM'` fork-name gates on the Honey/VR hardware CI lanes with explicit `vars.USE_VR_HARDWARE == 'true'` opt-in conditions across `runner-health.yml`, `self-hosted-fast.yml`, and `vr-hardware.yml`, and updates README, status, roadmap, and support-matrix docs to reflect the post-#29 CI topology.

The workflow logic is clean and the intent is correctly implemented, but `docs/support-matrix.md` was not fully brought in sync with the companion doc updates: the `yoga` install rows still read `Design` / \"no packages found\" despite `docs/status.md` (in this same PR) confirming v0.5.1 is installed and validated there, and the RPM row still describes v0.5.1 as an in-progress repair lane rather than a shipped artifact.

<h3>Confidence Score: 5/5</h3>

Safe to merge; CI logic is correct and all remaining findings are documentation inconsistencies.

All workflow changes are straightforward condition replacements with no logic errors. The only issues are P2 doc inconsistencies within support-matrix.md that contradict the status.md and README updated in the same PR — these don't affect CI behavior or runtime.

docs/support-matrix.md — yoga install rows and RPM status rows are out of sync with status.md and README.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/runner-health.yml | VR runner job correctly gated with `USE_SELFHOSTED && USE_VR_HARDWARE`; nix-runner falls back to ubuntu-latest as before. |
| .github/workflows/self-hosted-fast.yml | `fast-vr` job condition updated to `USE_SELFHOSTED && USE_VR_HARDWARE`; `needs: fast-build` dependency is consistent since both share the `USE_SELFHOSTED` requirement. |
| .github/workflows/vr-hardware.yml | All six jobs now gated on `USE_SELFHOSTED && USE_VR_HARDWARE`; tag-push trigger will produce empty/skipped runs when vars unset, which is the stated intent. |
| docs/support-matrix.md | Two contradictions with status.md/README: `yoga` install rows still say `Design` / "no packages found" despite v0.5.1 being validated there, and RPM row still describes v0.5.1 as an in-progress repair lane. |
| docs/status.md | Accurately reflects current state: v0.5.1 released, yoga package validated, Honey VR lane as explicit opt-in. |
| README.md | Updated scope statement and current-state table match the post-#29 CI topology described in the PR. |
| docs/roadmap-2026-q2.md | Epic 2 acceptance criteria updated to reference `USE_VR_HARDWARE` opt-in gate; content is internally consistent. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `docs/support-matrix.md`, line 23-24 ([link](https://github.com/jesssullivan/xoxdwm/blob/0e43aa4b179b33ab4a82abeb2355f4826a742f42/docs/support-matrix.md#L23-L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Support matrix contradicts status.md on `yoga` install**

   `docs/status.md` (updated in this same PR) explicitly states that `yoga` now has `exwm-vr`, `exwm-vr-compositor`, and `exwm-vr-elisp` installed, with "clean runtime linking" and "bounded compositor startup" validated. The support matrix still shows both rows as `Design` with notes saying "No XoxdWM binary or package install was found" and "No Monado/OpenXR/wlroots runtime packages … were found." Readers consulting the matrix will get a directly contradictory picture from the status doc.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/support-matrix.md
   Line: 23-24

   Comment:
   **Support matrix contradicts status.md on `yoga` install**

   `docs/status.md` (updated in this same PR) explicitly states that `yoga` now has `exwm-vr`, `exwm-vr-compositor`, and `exwm-vr-elisp` installed, with "clean runtime linking" and "bounded compositor startup" validated. The support matrix still shows both rows as `Design` with notes saying "No XoxdWM binary or package install was found" and "No Monado/OpenXR/wlroots runtime packages … were found." Readers consulting the matrix will get a directly contradictory picture from the status doc.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `docs/support-matrix.md`, line 30-31 ([link](https://github.com/jesssullivan/xoxdwm/blob/0e43aa4b179b33ab4a82abeb2355f4826a742f42/docs/support-matrix.md#L30-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `v0.5.0` notes; RPM status should be `Smoke` not `Design`**

   `docs/status.md` and `README.md` (both updated in this PR) describe `v0.5.1` as already publicly released with the Rocky RPM gate complete — native linking, no `/nix/store` deps, and host-install validated on `yoga`. The support matrix still frames `v0.5.1` as an "active repair lane" and keeps the `GitHub release RPM` row at `Design`. The `Rocky 10 quickstart` row likely needs the same update.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/support-matrix.md
   Line: 30-31

   Comment:
   **Stale `v0.5.0` notes; RPM status should be `Smoke` not `Design`**

   `docs/status.md` and `README.md` (both updated in this PR) describe `v0.5.1` as already publicly released with the Rocky RPM gate complete — native linking, no `/nix/store` deps, and host-install validated on `yoga`. The support matrix still frames `v0.5.1` as an "active repair lane" and keeps the `GitHub release RPM` row at `Design`. The `Rocky 10 quickstart` row likely needs the same update.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/support-matrix.md
Line: 23-24

Comment:
**Support matrix contradicts status.md on `yoga` install**

`docs/status.md` (updated in this same PR) explicitly states that `yoga` now has `exwm-vr`, `exwm-vr-compositor`, and `exwm-vr-elisp` installed, with "clean runtime linking" and "bounded compositor startup" validated. The support matrix still shows both rows as `Design` with notes saying "No XoxdWM binary or package install was found" and "No Monado/OpenXR/wlroots runtime packages … were found." Readers consulting the matrix will get a directly contradictory picture from the status doc.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/support-matrix.md
Line: 30-31

Comment:
**Stale `v0.5.0` notes; RPM status should be `Smoke` not `Design`**

`docs/status.md` and `README.md` (both updated in this PR) describe `v0.5.1` as already publicly released with the Rocky RPM gate complete — native linking, no `/nix/store` deps, and host-install validated on `yoga`. The support matrix still frames `v0.5.1` as an "active repair lane" and keeps the `GitHub release RPM` row at `Design`. The `Rocky 10 quickstart` row likely needs the same update.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: gate Honey hardware lanes explicitly"](https://github.com/jesssullivan/xoxdwm/commit/0e43aa4b179b33ab4a82abeb2355f4826a742f42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28919304)</sub>

<!-- /greptile_comment -->