### PR TITLE
[codex] Prefer preinstalled Nix on self-hosted fast paths

### DIFF
--- a/.github/actions/ensure-nix/action.yml
+++ b/.github/actions/ensure-nix/action.yml
@@ -1,0 +1,32 @@
+name: Ensure Nix
+description: Prefer a preinstalled Nix toolchain and bootstrap only when absent
+
+runs:
+  using: composite
+  steps:
+    - name: Detect preinstalled Nix
+      id: detect-nix
+      shell: bash
+      run: |
+        if command -v nix >/dev/null 2>&1; then
+          echo "needs_bootstrap=false" >> "$GITHUB_OUTPUT"
+          echo "nix_bin=$(command -v nix)" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "needs_bootstrap=true" >> "$GITHUB_OUTPUT"
+
+    - name: Bootstrap Nix
+      if: steps.detect-nix.outputs.needs_bootstrap == 'true'
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Verify Nix toolchain
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "${{ steps.detect-nix.outputs.needs_bootstrap }}" = "false" ]; then
+          echo "Using preinstalled Nix at ${{ steps.detect-nix.outputs.nix_bin }}"
+        else
+          echo "Bootstrapped Nix for this runner"
+        fi
+        nix --version

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/ensure-nix
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/ensure-nix
       - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
         with:
           attic-cache: ${{ env.ATTIC_CACHE || 'main' }}
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/ensure-nix
       - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
         with:
           attic-cache: ${{ env.ATTIC_CACHE || 'main' }}
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: ./.github/actions/ensure-nix
       - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
         with:
           attic-cache: ${{ env.ATTIC_CACHE || 'main' }}


### PR DESCRIPTION
## What changed
- added a repo-local `ensure-nix` composite action
- switched the self-hosted fast CI workflow to use that helper in `fast-check`, `fast-build`, and `fast-vr`
- switched the `Runner Health Check` Nix job to the same helper

## Why
These jobs are the repo’s runner-owned fast path, but they still unconditionally ran the Nix installer even on hosts that are supposed to come up with Nix already present. That makes the contract noisier than it needs to be and hides whether the runner image is actually healthy.

## Impact
- self-hosted fast-path jobs now prefer the preinstalled Nix toolchain
- hosted fallback still works because the helper bootstraps Nix when it is absent
- no changes to job selection, gating, or Attic setup

## Validation
- `git diff --check`
- Ruby YAML parse of the new action and both touched workflows

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a repo-local `ensure-nix` composite action that short-circuits the Nix installer when a preinstalled toolchain is detected, then wires it into `fast-check`, `fast-build`, `fast-vr`, and the runner health check. The logic is sound and the fallback bootstrap path is preserved for hosted runners.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only finding is a P2 style suggestion on the installer's mutable ref.

All remaining feedback is P2 (floating `@main` pin). No logic errors, no security exploits, no correctness issues in the changed files.

`.github/actions/ensure-nix/action.yml` — consider pinning the `DeterminateSystems/nix-installer-action` ref.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/ensure-nix/action.yml | New composite action that short-circuits installation when Nix is already present; logic is correct but bootstrapper is pinned to the mutable `@main` ref. |
| .github/workflows/runner-health.yml | Replaces inline Nix installer step with the new `ensure-nix` composite action; no logic changes to the health checks themselves. |
| .github/workflows/self-hosted-fast.yml | Adds `ensure-nix` step to `fast-check`, `fast-build`, and `fast-vr` jobs; no other changes to job logic, gating, or Attic setup. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/actions/ensure-nix/action.yml
Line: 21

Comment:
**Floating `@main` ref for installer action**

`DeterminateSystems/nix-installer-action@main` resolves to whatever commit the upstream repo's `main` branch points to at run time. A breaking change or supply chain compromise there would silently affect every job that calls this action. Prefer a pinned SHA or a tagged release (e.g. `@v4`).

```suggestion
      uses: DeterminateSystems/nix-installer-action@v4
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: retrigger self-hosted fast checks"](https://github.com/jesssullivan/xoxdwm/commit/2fd18b9be888349b3e35243a4b40bf6e4069af56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29154189)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->