### PR TITLE
Align self-hosted workflows with xoxdwm-nix

### DIFF
--- a/.github/actions/ensure-nix/action.yml
+++ b/.github/actions/ensure-nix/action.yml
@@ -1,0 +1,62 @@
+name: Ensure Nix
+description: Install or recover Nix for hosted and self-hosted workflows.
+
+inputs:
+  self_hosted:
+    description: Whether the current job is running on a self-hosted runner.
+    required: false
+    default: "false"
+  attic_cache:
+    description: Preferred Attic cache name for self-hosted flywheel setup.
+    required: false
+    default: "main"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix on hosted runners
+      if: ${{ inputs.self_hosted != 'true' }}
+      uses: cachix/install-nix-action@v30
+
+    - name: Install Nix on self-hosted runners
+      if: ${{ inputs.self_hosted == 'true' }}
+      uses: DeterminateSystems/nix-installer-action@main
+
+    - name: Setup self-hosted cache hints
+      if: ${{ inputs.self_hosted == 'true' }}
+      uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      with:
+        attic-cache: ${{ inputs.attic_cache }}
+
+    - name: Ensure Nix daemon is reachable
+      if: ${{ inputs.self_hosted == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if nix store ping >/dev/null 2>&1; then
+          exit 0
+        fi
+
+        echo "::warning::Nix is installed but the daemon socket is unavailable; starting the Nix daemon stack"
+        sudo rm -f /nix/var/nix/daemon-socket/socket || true
+        if command -v determinate-nixd >/dev/null 2>&1; then
+          sudo -b "$(command -v determinate-nixd)" daemon
+        else
+          NIX_DAEMON_BIN="$(command -v nix-daemon || true)"
+          if [ -z "$NIX_DAEMON_BIN" ]; then
+            echo "::error::nix-daemon is not on PATH, and nix store ping failed"
+            exit 1
+          fi
+          sudo -b "$NIX_DAEMON_BIN" --daemon
+        fi
+
+        for _ in $(seq 1 15); do
+          if nix store ping >/dev/null 2>&1; then
+            exit 0
+          fi
+          sleep 1
+        done
+
+        echo "::error::nix-daemon did not become reachable after restart"
+        exit 1

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -33,7 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -66,7 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -96,7 +102,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -120,7 +129,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -142,7 +154,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build-x86_64:
     name: Build x86_64 (full + VR)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
   build-headless:
     name: Build x86_64 (headless)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
 
   ert-tests:
     name: ERT Tests
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
 
   cross-aarch64:
     name: Cross-compile aarch64
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     continue-on-error: true
     steps:
@@ -137,7 +137,7 @@ jobs:
 
   cross-s390x:
     name: Cross-compile s390x
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -32,7 +32,7 @@ jobs:
   # ── Nix build (self-hosted) ──────────────────────────────
   nix-build:
     name: Nix Build (wlroots + sway)
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -37,7 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     name: Nix Build
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -25,9 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Nix
-        if: vars.USE_SELFHOSTED != 'true'
-        uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - name: Verify Nix
         run: nix --version
       - uses: ryanccn/attic-action@v0

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -37,7 +37,10 @@ jobs:
         run: |
           python3 scripts/stamp-release-version.py "${{ steps.version.outputs.version }}"
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build-binary:
     name: Build Compositor Binary
-    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELFHOSTED == 'true' && 'xoxdwm-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - uses: ./.github/actions/ensure-nix
         with:
-          attic-cache: ${{ env.ATTIC_CACHE || 'main' }}
+          self_hosted: "true"
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
 
       - uses: ryanccn/attic-action@v0
         continue-on-error: true
@@ -102,10 +102,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - uses: ./.github/actions/ensure-nix
         with:
-          attic-cache: ${{ env.ATTIC_CACHE || 'main' }}
+          self_hosted: "true"
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
 
       - uses: ryanccn/attic-action@v0
         continue-on-error: true
@@ -147,10 +147,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+      - uses: ./.github/actions/ensure-nix
         with:
-          attic-cache: ${{ env.ATTIC_CACHE || 'main' }}
+          self_hosted: "true"
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
 
       - uses: ryanccn/attic-action@v0
         continue-on-error: true

--- a/.github/workflows/vr-hardware.yml
+++ b/.github/workflows/vr-hardware.yml
@@ -66,7 +66,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -93,7 +96,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -132,7 +138,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -167,7 +176,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:
@@ -210,7 +222,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v30
+      - uses: ./.github/actions/ensure-nix
+        with:
+          self_hosted: ${{ vars.USE_SELFHOSTED }}
+          attic_cache: ${{ env.ATTIC_CACHE || 'main' }}
       - uses: ryanccn/attic-action@v0
         if: env.ATTIC_SERVER != ''
         with:


### PR DESCRIPTION
## Summary
- point the remaining Jess-repo self-hosted workflows at `xoxdwm-nix`
- keep the repo-scoped fast path consistent with the live ARC scale set
- stop dispatching queued maintenance jobs onto `tinyland-nix` for this repo

## Testing
- git diff --check
- manual dispatch of `multi-arch.yml` on this branch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates all self-hosted Nix setup logic into a new `ensure-nix` composite action and migrates every workflow's runner label from `tinyland-nix` to `xoxdwm-nix`. The changes are mechanical and applied consistently across all seven files.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only open finding is a P2 supply-chain hygiene suggestion about unpinned @main refs in external actions.

All workflow changes are mechanical runner-label and Nix-setup consolidations with no logic regressions. The single finding (unpinned @main on external actions) is a pre-existing pattern from self-hosted-fast.yml and is P2 — it does not block merge.

.github/actions/ensure-nix/action.yml — review the @main pins on DeterminateSystems and GloriousFlywheel actions before future changes expand their usage further.

<details open><summary><h3>Security Review</h3></summary>

- `DeterminateSystems/nix-installer-action@main` and `tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main` in `.github/actions/ensure-nix/action.yml` use floating `@main` refs. Any commit pushed to the HEAD of those external repos executes immediately in this repo's CI (code execution under `sudo`). Pinning to a commit SHA or stable tag eliminates this attack surface.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/ensure-nix/action.yml | New composite action centralising Nix install/daemon-recovery logic; correctly branches on self_hosted input, but two external actions are pinned to floating @main refs. |
| .github/workflows/multi-arch.yml | Runner label changed from tinyland-nix to xoxdwm-nix and direct cachix/install-nix-action replaced with ensure-nix composite action across all five jobs; changes are mechanical and consistent. |
| .github/workflows/self-hosted-fast.yml | Two-step DeterminateSystems + GloriousFlywheel setup collapsed into ensure-nix with self_hosted hardcoded to "true"; semantically equivalent. |
| .github/workflows/vr-hardware.yml | Five jobs updated to use ensure-nix; all jobs already guard on vars.USE_SELFHOSTED == 'true', so the self_hosted input will always resolve to 'true' at runtime — correct behaviour. |
| .github/workflows/nix-cache.yml | Runner label updated to xoxdwm-nix and Nix setup delegated to ensure-nix composite action; no other logic changes. |
| .github/workflows/native-deps.yml | nix-build job runner updated to xoxdwm-nix and Nix setup replaced with ensure-nix; rpm-build job is unchanged and still uses ubuntu-latest. |
| .github/workflows/packaging.yml | Runner label and Nix setup updated consistently with other workflows; stamp-release-version step remains before ensure-nix, which is fine since python3 is pre-installed on the runner. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/actions/ensure-nix/action.yml
Line: 23-27

Comment:
**Unpinned external actions at `@main`**

`DeterminateSystems/nix-installer-action@main` and `tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main` both float on the `main` branch of external repos. Any commit pushed to either repo's main branch will immediately execute in this repository's CI without any review. Pinning to a specific commit SHA (or at minimum a tag) removes that supply-chain attack surface. Note that `cachix/install-nix-action` is already pinned to `@v30`, so the pattern is inconsistent.

(Replace with the exact release tag / SHA you intend to track.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Use shared Nix bootstrap in self-hosted ..."](https://github.com/jesssullivan/xoxdwm/commit/6be8fa36f08db3245a94099ee412bb6cf103dcfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29162347)</sub>

<!-- /greptile_comment -->