### PR TITLE
Document Dell host evidence boundary

### DIFF
--- a/docs/remote-build-authority.md
+++ b/docs/remote-build-authority.md
@@ -121,6 +121,29 @@ Current truth from that repo:
   active upstreamable split; SMI, NUMA, tuned-profile, and rollback validation
   remain Dell-7810/XoxdWM operator surfaces rather than kernel-patch carry
 
+### `Jesssullivan/Dell-7810`
+
+The local sibling repo at `/Users/jess/git/Dell-7810` is the Dell Precision
+7810 host-evidence authority for `honey`.
+
+Relevant references there:
+
+- [docs/platform/rt-research-contract.md](</Users/jess/git/Dell-7810/docs/platform/rt-research-contract.md>)
+- [docs/tracking/rt-smi-numa-chapel-focus-2026-04-25.md](</Users/jess/git/Dell-7810/docs/tracking/rt-smi-numa-chapel-focus-2026-04-25.md>)
+- [docs/platform/authority-map.md](</Users/jess/git/Dell-7810/docs/platform/authority-map.md>)
+- [docs/platform/xoxdwm-symbiosis-touchpoints.md](</Users/jess/git/Dell-7810/docs/platform/xoxdwm-symbiosis-touchpoints.md>)
+
+What those docs make explicit:
+
+- Dell-7810 owns BIOS, SMI, RT/NUMA, reset, fan, enclosure, and Chapel host
+  probe evidence for `honey`
+- XoxdWM may consume that evidence as a named-host precondition, but XoxdWM
+  should not restate Dell raw measurements as software proof
+- XoxdWM owns downstream software-benefit claims, especially `C4` RT benefit
+  claims
+- generic-lane Chapel evidence exists in Dell-7810, while RT-lane Chapel
+  evidence remains a Dell follow-up before any software-side claim should use it
+
 ### `tinyland-inc/GloriousFlywheel`
 
 The local sibling repo at `/Users/jess/git/GloriousFlywheel` is the runner and


### PR DESCRIPTION
## Summary

Adds the Dell-7810 host-evidence authority to the XoxdWM remote-build authority map.

This keeps SMI, NUMA, RT, reset, fan, enclosure, and Chapel host-probe evidence anchored in `Jesssullivan/Dell-7810`, while XoxdWM only consumes those facts as named-host preconditions and retains ownership of downstream software-benefit claims such as C4 RT/XR benefit.

## Validation

- `git diff --check`
- `just truth-lint` 18/18

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `Jesssullivan/Dell-7810` section to `docs/remote-build-authority.md`, registering it as the host-evidence authority for `honey` and clarifying the evidence-ownership boundary between Dell-7810 and XoxdWM. The change is documentation-only and follows the existing local-sibling-repo reference pattern used throughout the file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only change with no code impact.

The change is a single documentation addition with no code, logic, security, or memory-safety implications. It follows the established style and pattern of the file exactly.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/remote-build-authority.md | Adds a new `Jesssullivan/Dell-7810` authority section following the established local-sibling-repo pattern; content and style are consistent with existing sections. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Dell host evidence authority"](https://github.com/jesssullivan/xoxdwm/commit/f339a428d991ac494351658b493c9cb63c8c4253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29716586)</sub>

<!-- /greptile_comment -->