### PR TITLE
Package OpenXR smoke client for honey repeatability

### DIFF
--- a/.github/workflows/openxr-smoke-client.yml
+++ b/.github/workflows/openxr-smoke-client.yml
@@ -1,0 +1,115 @@
+name: OpenXR Smoke Client RPM
+
+on:
+  push:
+    paths:
+      - '.github/workflows/openxr-smoke-client.yml'
+      - 'packaging/rpm/exwm-vr-openxr-smoke-client.spec'
+      - 'packaging/scripts/exwm-vr-openxr-smoke'
+  pull_request:
+    paths:
+      - '.github/workflows/openxr-smoke-client.yml'
+      - 'packaging/rpm/exwm-vr-openxr-smoke-client.spec'
+      - 'packaging/scripts/exwm-vr-openxr-smoke'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-openxr-smoke-client:
+    name: Package OpenXR Smoke Client RPM
+    runs-on: ubuntu-latest
+    container: rockylinux/rockylinux:10
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install rpmbuild dependencies
+        run: |
+          dnf install -y \
+            'dnf-command(config-manager)' \
+            'https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm'
+          dnf config-manager --set-enabled crb || dnf config-manager setopt crb.enabled=1
+          dnf install -y \
+            bash curl tar gzip rpm-build rpmdevtools cmake ninja-build \
+            gcc-c++ python3 pkgconf-pkg-config openxr-devel \
+            vulkan-headers vulkan-loader-devel mesa-libGL-devel \
+            libX11-devel libXrandr-devel libXxf86vm-devel \
+            binutils cpio
+
+      - name: Set up rpmbuild tree
+        run: rpmdev-setuptree
+
+      - name: Download OpenXR SDK source tarball
+        run: |
+          set -euo pipefail
+          SDK_COMMIT=$(sed -n 's/^%global sdk_commit[[:space:]]*//p' packaging/rpm/exwm-vr-openxr-smoke-client.spec | head -1)
+          if [ -z "$SDK_COMMIT" ]; then
+            echo "Failed to parse OpenXR SDK commit from spec" >&2
+            exit 1
+          fi
+          curl -fsSL \
+            -o "$HOME/rpmbuild/SOURCES/OpenXR-SDK-Source-${SDK_COMMIT}.tar.gz" \
+            "https://github.com/KhronosGroup/OpenXR-SDK-Source/archive/${SDK_COMMIT}.tar.gz"
+
+      - name: Build OpenXR smoke client RPM
+        run: |
+          rpmbuild -bb --nodeps \
+            --define "_topdir $HOME/rpmbuild" \
+            packaging/rpm/exwm-vr-openxr-smoke-client.spec
+
+      - name: Validate OpenXR smoke client RPM
+        run: |
+          set -euo pipefail
+          RPM=$(find "$HOME/rpmbuild/RPMS" \
+            -name 'exwm-vr-openxr-smoke-client-[0-9]*.rpm' \
+            ! -name '*-debuginfo-*.rpm' \
+            ! -name '*-debugsource-*.rpm' \
+            | sort | head -1)
+          if [ -z "$RPM" ]; then
+            echo "No exwm-vr-openxr-smoke-client RPM found in rpmbuild output" >&2
+            exit 1
+          fi
+
+          for path in \
+            /usr/bin/exwm-vr-hello-xr \
+            /usr/libexec/exwm-vr/hello_xr
+          do
+            rpm -qpl "$RPM" | grep -Fx "$path" >/dev/null || {
+              echo "Missing expected payload path in OpenXR smoke client RPM: $path" >&2
+              exit 1
+            }
+          done
+          rpm -qplv "$RPM" \
+            | grep -F '/usr/bin/exwm-vr-hello-xr -> ../libexec/exwm-vr/hello_xr' >/dev/null || {
+              echo "OpenXR smoke client command symlink is not relative" >&2
+              exit 1
+            }
+
+          mkdir -p /tmp/openxr-rpm-validate
+          pushd /tmp/openxr-rpm-validate >/dev/null
+          rpm2cpio "$RPM" | cpio -idmv ./usr/libexec/exwm-vr/hello_xr >/dev/null 2>&1
+          if readelf -d usr/libexec/exwm-vr/hello_xr | grep -Eq '\((RPATH|RUNPATH)\)'; then
+            echo "hello_xr embeds an RPATH/RUNPATH; expected host runtime linking" >&2
+            exit 1
+          fi
+          if readelf -d usr/libexec/exwm-vr/hello_xr | grep -q '/nix/store\|rpmbuild/BUILD'; then
+            echo "hello_xr embeds a build-local RUNPATH; expected host runtime linking" >&2
+            exit 1
+          fi
+          popd >/dev/null
+
+      - name: Collect RPMs
+        run: |
+          mkdir -p rpms/
+          find "$HOME/rpmbuild/RPMS" -name '*.rpm' -exec cp {} rpms/ \;
+          ls -la rpms/
+
+      - name: Upload RPMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: openxr-smoke-client-rpm
+          path: 'rpms/*.rpm'
+          retention-days: 7

--- a/docs/hygiene-minisprint-2026-04-25.md
+++ b/docs/hygiene-minisprint-2026-04-25.md
@@ -57,6 +57,9 @@ then reconcile trackers, then widen repeatability work.
   so completed evidence no longer looks open.
 - [x] Keep `TIN-346` open until `honey` VR proof is repeatable, not just
   one-shot.
+- [x] Split the packaged OpenXR smoke-client blocker into `TIN-595` so the
+  next workstream can replace devshell or `/usr/local/bin/hello_xr`
+  dependence with an installed Rocky-compatible artifact.
 - [x] Keep `TIN-398` as the cross-repo honey RT/kernel posture lane.
 - [x] Treat `/private/tmp/xoxdwm-host-contract` as duplicate/equivalent work
   unless a later audit finds missing content.

--- a/docs/remote-build-authority.md
+++ b/docs/remote-build-authority.md
@@ -54,6 +54,7 @@ Do not turn `honey` into the Bazel control plane by default. Use `honey` for:
 - live XR/runtime proof
 - package install and host validation
 - systemd, OpenXR, Monado, DRM, and connector debugging
+- installed OpenXR smoke-client validation after a package is built
 
 Use `rockies` Bazel surfaces for:
 
@@ -169,6 +170,9 @@ Current truth from that repo:
   GloriousFlywheel actions, because GitHub resolves `uses:` actions before
   fallback step gating can protect them; `.github/actions/ensure-nix` carries
   the minimal local consumer shim
+- `openxr-smoke-client.yml` is an XoxdWM-owned companion RPM lane for the
+  Khronos `hello_xr` smoke client; it proves package buildability, while
+  installed `honey` runtime proof still belongs to named-host operator runs
 - `tinyland-inc/GloriousFlywheel#413` is the current tracker for proving
   `Jesssullivan/XoxdWM` can reach the shared `tinyland-nix` lane without
   recreating repo-shaped runner labels

--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -34,6 +34,7 @@ Not every remote workflow is authoritative in the same way.
 | Rocky userspace smoke | [.github/workflows/rocky-test.yml](../.github/workflows/rocky-test.yml) | `ubuntu-latest` with `rockylinux:10` container | bounded Rocky userspace and headless build smoke | `yoga`, `honey`, or custom Rockies build authority |
 | Release packaging | [.github/workflows/packaging.yml](../.github/workflows/packaging.yml) | mixed: `tinyland-nix` and hosted Rocky container jobs | release artifact production and bounded RPM metadata validation | deployed host truth or full VR package integration |
 | Monado companion packaging | [.github/workflows/monado-companion.yml](../.github/workflows/monado-companion.yml) | hosted Rocky container job | bounded Rocky RPM production for the companion Monado runtime lane | named-host proof or proof that the base compositor RPM now bundles Monado |
+| OpenXR smoke client packaging | [.github/workflows/openxr-smoke-client.yml](../.github/workflows/openxr-smoke-client.yml) | hosted Rocky container job | bounded Rocky RPM production for the Khronos `hello_xr` smoke-client lane | named-host proof or proof that the package is installed on `honey` |
 | Honey VR hardware | [.github/workflows/vr-hardware.yml](../.github/workflows/vr-hardware.yml) and `fast-vr` in [.github/workflows/self-hosted-fast.yml](../.github/workflows/self-hosted-fast.yml) | `[self-hosted, honey]` | GPU, DRM, Monado, and bounded VR smoke when hardware lanes are explicitly enabled | stable deployed XoxdWM VR desktop on `honey` |
 | External Rocky control plane | sibling repos [rockies](</Users/jess/git/rockies>), [linux-xr](</Volumes/linux-xr-cs/linux-xr>), and [GloriousFlywheel](</Users/jess/git/GloriousFlywheel>) | external | Rocky composition policy, kernel packaging, and runner/cache substrate | XoxdWM implementation truth by themselves |
 
@@ -55,6 +56,7 @@ Not every remote workflow is authoritative in the same way.
    - `just remote-runner-health`
    - `just remote-cache-warm`
    - `just remote-monado-package`
+   - `just remote-openxr-smoke-client-package`
    - `just remote-vr-smoke smoke`
 6. Treat `yoga` and `honey` host evidence as the only basis for support-matrix
    or status promotion.
@@ -130,6 +132,9 @@ and the
 - `packaging.yml` is a release lane, not a support claim.
 - `monado-companion.yml` is the Rocky companion-runtime packaging lane. A green
   run there means the Monado RPM is buildable, not that `honey` is done.
+- `openxr-smoke-client.yml` is the Rocky companion-client packaging lane. A
+  green run there means the smoke client RPM is buildable, not that the
+  installed `honey` operator path has been updated.
 - `vr-hardware.yml` should stay opt-in and capability-gated. A green run there
   is strong evidence, but it is still not the same thing as a repeatable named-host
   user session.

--- a/justfile
+++ b/justfile
@@ -541,6 +541,7 @@ remote-proof-surface:
     @echo "  rocky-test.yml         bounded Rocky container smoke"
     @echo "  packaging.yml          release artifact lane, not named-host support truth"
     @echo "  monado-companion.yml   companion Monado RPM lane, not host proof"
+    @echo "  openxr-smoke-client.yml OpenXR smoke client RPM lane, not host proof"
     @echo "  vr-hardware.yml        honey hardware and VR smoke, opt-in only"
     @echo ""
     @echo "Docs:"
@@ -563,6 +564,7 @@ remote-proof-runs limit="5":
         rocky-test.yml
         packaging.yml
         monado-companion.yml
+        openxr-smoke-client.yml
         vr-hardware.yml
     )
     for workflow in "${workflows[@]}"; do
@@ -600,6 +602,11 @@ remote-package version:
 [group('ci')]
 remote-monado-package:
     gh workflow run monado-companion.yml -R "{{xoxdwm_repo}}"
+    @echo "Triggered. Watch with: just remote-proof-runs"
+
+[group('ci')]
+remote-openxr-smoke-client-package:
+    gh workflow run openxr-smoke-client.yml -R "{{xoxdwm_repo}}"
     @echo "Triggered. Watch with: just remote-proof-runs"
 
 [group('ci')]

--- a/packaging/rpm/exwm-vr-openxr-smoke-client.spec
+++ b/packaging/rpm/exwm-vr-openxr-smoke-client.spec
@@ -1,0 +1,74 @@
+# RPM spec for the EXWM-VR OpenXR smoke client
+# Target: Rocky Linux 10
+
+%global sdk_commit b8e48244207d9a623649e4de8cdbe288997194c1
+%global sdk_date   20260425
+%global project_name exwm-vr
+
+Name:           exwm-vr-openxr-smoke-client
+Version:        0.0.1
+Release:        1.%{sdk_date}git%{?dist}
+Summary:        OpenXR smoke client for EXWM-VR host repeatability checks
+License:        Apache-2.0
+URL:            https://github.com/KhronosGroup/OpenXR-SDK-Source
+Source0:        https://github.com/KhronosGroup/OpenXR-SDK-Source/archive/%{sdk_commit}/OpenXR-SDK-Source-%{sdk_commit}.tar.gz
+
+BuildRequires:  cmake >= 3.16
+BuildRequires:  ninja-build
+BuildRequires:  gcc-c++
+BuildRequires:  python3
+BuildRequires:  pkgconfig
+BuildRequires:  openxr-devel
+BuildRequires:  vulkan-headers
+BuildRequires:  vulkan-loader-devel
+BuildRequires:  mesa-libGL-devel
+BuildRequires:  libX11-devel
+BuildRequires:  libXrandr-devel
+BuildRequires:  libXxf86vm-devel
+
+Requires:       openxr-libs
+Requires:       vulkan-loader
+Requires:       libX11
+Requires:       libXrandr
+Requires:       libXxf86vm
+
+%description
+This package builds the Khronos OpenXR SDK hello_xr sample as a bounded smoke
+client for EXWM-VR host repeatability checks. It installs the binary under the
+EXWM-VR libexec tree and exposes an exwm-vr-hello-xr command name so the
+operator wrapper can prefer a repo-managed client path over host-local
+/usr/local binaries.
+
+%prep
+%autosetup -n OpenXR-SDK-Source-%{sdk_commit}
+
+%build
+%cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_SKIP_RPATH=ON \
+    -DCMAKE_SKIP_BUILD_RPATH=ON \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF \
+    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF \
+    -DBUILD_API_LAYERS=OFF \
+    -DBUILD_CONFORMANCE_TESTS=OFF \
+    -DBUILD_TESTS=ON \
+    -DBUILD_SDK_TESTS=ON \
+    -DPRESENTATION_BACKEND=xlib
+%cmake_build --target hello_xr
+
+%install
+install -Dpm 0755 %{__cmake_builddir}/src/tests/hello_xr/hello_xr \
+    %{buildroot}%{_libexecdir}/%{project_name}/hello_xr
+install -d %{buildroot}%{_bindir}
+ln -s ../libexec/%{project_name}/hello_xr \
+    %{buildroot}%{_bindir}/exwm-vr-hello-xr
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/exwm-vr-hello-xr
+%{_libexecdir}/%{project_name}/hello_xr
+
+%changelog
+* Sat Apr 25 2026 EXWM-VR <noreply@example.com> - 0.0.1-1
+- Initial package: Khronos hello_xr smoke client for honey repeatability.

--- a/packaging/scripts/exwm-vr-openxr-smoke
+++ b/packaging/scripts/exwm-vr-openxr-smoke
@@ -92,6 +92,9 @@ resolve_client() {
     fi
 
     for candidate in \
+        /usr/libexec/exwm-vr/hello_xr \
+        exwm-vr-hello-xr \
+        /usr/bin/exwm-vr-hello-xr \
         hello_xr \
         /usr/local/bin/hello_xr \
         /usr/bin/hello_xr \
@@ -117,9 +120,13 @@ if [[ -n "$client_path" ]]; then
     client_name="$(basename "$client_path")"
 fi
 
-if ((${#client_args[@]} == 0)) && [[ "$client_name" = "hello_xr" ]]; then
-    client_args=(-g Vulkan)
-fi
+case "$client_name" in
+    hello_xr|exwm-vr-hello-xr)
+        if ((${#client_args[@]} == 0)); then
+            client_args=(-g Vulkan)
+        fi
+        ;;
+esac
 
 socket_status() {
     local path="$1"
@@ -201,7 +208,7 @@ if [[ ! -e "$XR_RUNTIME_JSON" ]]; then
 fi
 
 if [[ -z "$client_path" ]]; then
-    echo "ERROR: no OpenXR smoke client found. Set EXWM_VR_OPENXR_CLIENT or install hello_xr/openxr-info/xrgears." >&2
+    echo "ERROR: no OpenXR smoke client found. Set EXWM_VR_OPENXR_CLIENT or install exwm-vr-hello-xr/hello_xr/openxr-info/xrgears." >&2
     exit 127
 fi
 

--- a/test/honey-substrate-test.el
+++ b/test/honey-substrate-test.el
@@ -16,6 +16,14 @@
   (expand-file-name ".github/workflows/monado-companion.yml"
                     (expand-file-name ".." (file-name-directory load-file-name))))
 
+(defconst honey-substrate--openxr-smoke-client-spec
+  (expand-file-name "packaging/rpm/exwm-vr-openxr-smoke-client.spec"
+                    (expand-file-name ".." (file-name-directory load-file-name))))
+
+(defconst honey-substrate--openxr-smoke-client-workflow
+  (expand-file-name ".github/workflows/openxr-smoke-client.yml"
+                    (expand-file-name ".." (file-name-directory load-file-name))))
+
 (defconst honey-substrate--native-deps-workflow
   (expand-file-name ".github/workflows/native-deps.yml"
                     (expand-file-name ".." (file-name-directory load-file-name))))
@@ -109,10 +117,40 @@
       (should (string-match-p (regexp-quote "runtime_library_path=") script))
       (should (string-match-p (regexp-quote "exwm_vr_compositor_service") script))
       (should (string-match-p (regexp-quote "exwm_vr_monado_service") script))
+      (should (string-match-p (regexp-quote "/usr/libexec/exwm-vr/hello_xr") script))
+      (should (string-match-p (regexp-quote "exwm-vr-hello-xr") script))
       (should (string-match-p (regexp-quote "/usr/local/bin/hello_xr") script))
       (should (string-match-p (regexp-quote "timeout \"$timeout_seconds\"") script))
       (should (string-match-p (regexp-quote "monado_comp_ipc") script))
       (should (string-match-p (regexp-quote "openxr_smoke=passed_after_ready_timeout") script)))))
+
+(ert-deftest honey-substrate/openxr-smoke-client-rpm-lane-builds-packaged-client ()
+  "The OpenXR smoke client RPM lane should package a repo-managed client path."
+  (with-temp-buffer
+    (insert-file-contents honey-substrate--openxr-smoke-client-spec)
+    (let ((spec (buffer-string)))
+      (should (string-match-p (regexp-quote "Name:           exwm-vr-openxr-smoke-client") spec))
+      (should (string-match-p (regexp-quote "KhronosGroup/OpenXR-SDK-Source") spec))
+      (should (string-match-p (regexp-quote "PRESENTATION_BACKEND=xlib") spec))
+      (should (string-match-p (regexp-quote "-DCMAKE_SKIP_RPATH=ON") spec))
+      (should (string-match-p (regexp-quote "../libexec/%{project_name}/hello_xr") spec))
+      (should (string-match-p (regexp-quote "%{_libexecdir}/%{project_name}/hello_xr") spec))
+      (should (string-match-p (regexp-quote "%{_bindir}/exwm-vr-hello-xr") spec))
+      (should (string-match-p (regexp-quote "openxr-libs") spec))
+      (should (string-match-p (regexp-quote "vulkan-loader") spec))))
+  (with-temp-buffer
+    (insert-file-contents honey-substrate--openxr-smoke-client-workflow)
+    (let ((workflow (buffer-string)))
+      (should (string-match-p (regexp-quote "container: rockylinux/rockylinux:10") workflow))
+      (should (string-match-p (regexp-quote "packaging/rpm/exwm-vr-openxr-smoke-client.spec") workflow))
+      (should (string-match-p (regexp-quote "OpenXR-SDK-Source-${SDK_COMMIT}.tar.gz") workflow))
+      (should (string-match-p (regexp-quote "exwm-vr-openxr-smoke-client-[0-9]*.rpm") workflow))
+      (should (string-match-p (regexp-quote "/usr/bin/exwm-vr-hello-xr") workflow))
+      (should (string-match-p (regexp-quote "/usr/bin/exwm-vr-hello-xr -> ../libexec/exwm-vr/hello_xr") workflow))
+      (should (string-match-p (regexp-quote "/usr/libexec/exwm-vr/hello_xr") workflow))
+      (should (string-match-p (regexp-quote "RPATH|RUNPATH") workflow))
+      (should (string-match-p (regexp-quote "! -name '*-debuginfo-*.rpm'") workflow))
+      (should (string-match-p (regexp-quote "! -name '*-debugsource-*.rpm'") workflow)))))
 
 (ert-deftest honey-substrate/exwm-vr-monado-package-installs-openxr-smoke-wrapper ()
   "The opt-in Monado subpackage should carry the repo-owned OpenXR smoke wrapper."

--- a/test/truth-surface-test.el
+++ b/test/truth-surface-test.el
@@ -138,6 +138,7 @@
                         "rocky-test.yml"
                         "packaging.yml"
                         "monado-companion.yml"
+                        "openxr-smoke-client.yml"
                         "vr-hardware.yml"))
       (should (string-match-p (regexp-quote workflow) doc))
       (should (file-exists-p
@@ -150,6 +151,7 @@
                       "remote-monado-package"
                       "remote-vr-smoke"
                       "remote-package"
+                      "remote-openxr-smoke-client-package"
                       "honey-shell"
                       "honey-devshell"
                       "honey-run"


### PR DESCRIPTION
## Summary

Adds a bounded Rocky 10 RPM lane for a repo-managed OpenXR smoke client so the `honey` repeatability path can move off devshell-only or `/usr/local/bin/hello_xr` provenance.

## What Changed

- Add `packaging/rpm/exwm-vr-openxr-smoke-client.spec` to build Khronos `hello_xr` from a pinned OpenXR SDK source commit.
- Add `.github/workflows/openxr-smoke-client.yml` to build and validate the RPM in a Rocky 10 container.
- Teach `packaging/scripts/exwm-vr-openxr-smoke` to prefer `/usr/libexec/exwm-vr/hello_xr` or `exwm-vr-hello-xr` before fallback host-local clients.
- Register the new remote proof workflow in `justfile` and the remote-proof docs.
- Add truth-surface/ERT coverage for the packaged client lane, symlink target, and no-RPATH validation.

## Validation

- `bash -n packaging/scripts/exwm-vr-openxr-smoke`
- `git diff --check`
- `emacs --batch -l test/honey-substrate-test.el -f ert-run-tests-batch-and-exit` passed 16/16
- `just truth-lint` passed 18/18
- `just test` passed 1939/1939
- `honey` rootless Podman Rocky 10 RPM build passed from `/tmp/xoxdwm-tin595-build` without host package/service changes
- Honey RPM validation proved `/usr/bin/exwm-vr-hello-xr -> ../libexec/exwm-vr/hello_xr`, `/usr/libexec/exwm-vr/hello_xr`, and no `RPATH`/`RUNPATH` in the packaged binary

## Tracker

Refs TIN-595.
Refs #20.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a bounded Rocky 10 RPM lane for the Khronos `hello_xr` smoke client, wiring it into CI, the `justfile`, docs, and ERT tests so the `honey` repeatability path can prefer a repo-managed binary over devshell or host-local `/usr/local/bin` provenance. The implementation is coherent and well-covered by tests; all P2 findings are in the build tooling rather than the wrapper logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 style/best-practice items with no runtime impact.

P2s only: missing tarball checksum, non-standard Release tag convention, silent cpio extraction, and a redundant candidate in the resolver. None affect correctness of the packaged binary or the wrapper script's runtime behavior.

.github/workflows/openxr-smoke-client.yml (tarball integrity and cpio diagnostics) and packaging/rpm/exwm-vr-openxr-smoke-client.spec (Release tag convention).

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/openxr-smoke-client.yml | New CI workflow builds and validates the OpenXR smoke client RPM in a Rocky 10 container; missing tarball checksum verification and silent cpio extraction could obscure failures. |
| packaging/rpm/exwm-vr-openxr-smoke-client.spec | Well-structured RPM spec building hello_xr from a pinned commit with RPATH disabled; Release tag uses a non-standard snapshot convention that could cause upgrade ordering issues. |
| packaging/scripts/exwm-vr-openxr-smoke | Client resolution order correctly prefers packaged paths; case statement extended to cover the new exwm-vr-hello-xr name; minor redundancy in candidate list. |
| test/honey-substrate-test.el | New ERT tests verify spec contents, workflow presence, symlink target, and RPATH validation strings; good coverage of the new lane. |
| test/truth-surface-test.el | Adds openxr-smoke-client.yml and remote-openxr-smoke-client-package to the truth-surface checklist; straightforward extension of existing pattern. |
| justfile | Registers the new remote-openxr-smoke-client-package target and adds the workflow to the proof-surface display and run list; no issues. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/openxr-smoke-client.yml
Line: 55-66

Comment:
**No checksum verification for downloaded source tarball**

The source archive is downloaded and passed directly to `rpmbuild` without any hash check. Even though `sdk_commit` is pinned, GitHub regenerates release tarballs on demand, so the bytes can silently shift. A `sha256sum` guard would lock the build to a known-good archive and improve supply-chain repeatability.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/openxr-smoke-client.yml
Line: 85-89

Comment:
**Silent `cpio` extraction can mask a missing binary path**

`>/dev/null 2>&1` suppresses all `cpio` output including the "no files extracted" warning. If the archive path prefix doesn't match `./usr/libexec/exwm-vr/hello_xr`, `cpio` exits 0, no file is created, and the subsequent `readelf` fails with an opaque "No such file or directory" rather than a meaningful build error. Keeping at least stderr visible (or asserting the file exists after extraction) would make failures easier to diagnose.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packaging/rpm/exwm-vr-openxr-smoke-client.spec
Line: 10

Comment:
**Non-standard `Release` tag may cause unexpected upgrade ordering**

The `Release: 1.%{sdk_date}git%{?dist}` tag starts at `1`, which is unconventional for a pre-release snapshot build. The standard RPM snapshot convention uses `0.YYYYMMDD.gitSHORTHASH` (starting at `0`) so that future stable releases with `Release: 1` sort higher. Starting at `1` means any later formal version at `Release: 1` would not upgrade this package with `dnf update` because the EVR would compare equal.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packaging/scripts/exwm-vr-openxr-smoke
Line: 94-98

Comment:
**Redundant candidate after PATH lookup**

`exwm-vr-hello-xr` (line 96) is resolved via `command -v`, which will return `/usr/bin/exwm-vr-hello-xr` when the package is installed. The explicit absolute path `/usr/bin/exwm-vr-hello-xr` on line 97 is therefore only reached if `command -v` fails for a reason other than the binary being missing. Removing the duplicate absolute path simplifies the candidate list.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add OpenXR smoke client RPM lane"](https://github.com/jesssullivan/xoxdwm/commit/efd8f388838cea6255f20930a8c8f1fabcbb2532) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29722278)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->