### PR TITLE
Add honey OpenXR fresh-boot check lane

### DIFF
--- a/docs/honey-substrate-proof-2026-04-22.md
+++ b/docs/honey-substrate-proof-2026-04-22.md
@@ -437,6 +437,8 @@ unstructured SSH command:
 - remote helpers from `neo`:
   - `just honey-openxr-status`
   - `just honey-openxr-smoke`
+  - `just honey-openxr-clean-cycle`
+  - `just honey-openxr-fresh-boot-check`
 
 The status mode is intentionally non-disruptive. It reports:
 
@@ -605,6 +607,20 @@ service state, socket state, and `rke2-server=active` result.
 This narrows the remaining repeatability gap to fresh boot, in-goggles
 first-frame, and longer-running stability.
 
+## Fresh-Boot Check Lane
+
+The next post-boot capture path is now repo-owned:
+
+- `just honey-openxr-fresh-boot-check honey 1 20`
+
+This command does not reboot `honey`. It is intended to be run only after an
+attended/manual fresh boot has completed. It records host identity, repo head,
+boot ID, uptime, kernel, `rke2` service state, and the OpenXR status preflight,
+then delegates to `just honey-openxr-clean-cycle` for the packaged smoke run.
+
+As of this note, that target is prepared but has not yet produced fresh-boot
+evidence.
+
 ## What This Does Not Yet Prove
 
 - a stable deployed operator lane on `honey`
@@ -623,7 +639,8 @@ first-frame, and longer-running stability.
   host configuration surface for `honey`
 - keep stale `/run/user/1000/monado_comp_ipc` cleanup explicit in the Monado
   launcher and use `just honey-openxr-status` before disruptive VR reruns
-- repeat the installed `exwm-vr-openxr-smoke-client` lane across fresh-boot
-  cycles
+- after an attended/manual fresh boot, run
+  `just honey-openxr-fresh-boot-check honey 1 20` to repeat the installed
+  `exwm-vr-openxr-smoke-client` lane across fresh-boot cycles
 - keep the older fallback `VK_ERROR_SURFACE_LOST_KHR` crash categorized as a
   separate Monado window-path problem, not the whole bridge story

--- a/docs/hygiene-minisprint-2026-04-25.md
+++ b/docs/hygiene-minisprint-2026-04-25.md
@@ -90,7 +90,9 @@ then reconcile trackers, then widen repeatability work.
   here.
 - [ ] Convert `honey` from clean service-cycle Smoke toward fresh-boot
   repeatability only through stale IPC cleanup, durable packaged client
-  tooling, and repeated operator runs.
+  tooling, and repeated operator runs. The next repo-owned capture lane is
+  `just honey-openxr-fresh-boot-check honey 1 20`; it is prepared but should be
+  run only after an attended/manual fresh boot.
 
 ## Parallel Work Packages
 
@@ -275,6 +277,9 @@ Current facts:
   user-service session on `2026-04-25` EDT.
 - Three clean stop/start cycles also passed on `2026-04-25` EDT; the
   repo-owned command is `just honey-openxr-clean-cycle`.
+- `just honey-openxr-fresh-boot-check` is prepared for the next attended/manual
+  fresh boot; it records post-boot identity and status before delegating to the
+  clean-cycle smoke lane, and it does not reboot or stop `rke2`.
 
 Tasks:
 
@@ -283,8 +288,9 @@ Tasks:
 2. Keep the packaged `exwm-vr-openxr-smoke-client` path as the client-tool
    authority for future smoke runs; avoid returning to ad hoc
    `/usr/local/bin/hello_xr` evidence.
-3. Rerun the installed `honey` path across fresh-boot cycles before
-   classifying it as a stable operator lane.
+3. After an attended/manual reboot, run
+   `just honey-openxr-fresh-boot-check honey 1 20` before classifying the
+   installed `honey` path as a stable operator lane.
 4. Record failures as either host/substrate, packaging/deployment, or
    compositor/runtime integration blockers.
 5. Keep Dell reset and power findings in Dell-7810, with only sanitized

--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -51,6 +51,7 @@ Not every remote workflow is authoritative in the same way.
    - `just honey-openxr-status`
    - `just honey-openxr-smoke`
    - `just honey-openxr-clean-cycle`
+   - `just honey-openxr-fresh-boot-check`
 4. Inspect the live remote surface with `just remote-proof-surface` and
    `just remote-proof-runs`.
 5. Dispatch bounded remote checks when needed:
@@ -106,6 +107,11 @@ The repo now has a thin explicit remote-dev/operator lane for working from
     packaged OpenXR smoke client
   - this intentionally exercises the clean service-cycle lane and does not
     stop or restart `rke2`
+- `just honey-openxr-fresh-boot-check`
+  - print post-boot host identity, repo head, boot ID, uptime, kernel, `rke2`
+    state, and OpenXR status, then run `just honey-openxr-clean-cycle`
+  - this target does not reboot `honey`; run it only after an attended/manual
+    fresh boot has completed
 
 This lane is for live host work such as:
 
@@ -142,8 +148,10 @@ and the
   green run there means the smoke client RPM is buildable. The artifact from
   run `24938791255` has since been installed on `honey` and selected by
   `just honey-openxr-status`; `just honey-openxr-clean-cycle` now proves clean
-  user-service-cycle smoke, while fresh-boot and in-goggles first-frame proof
-  remain separate named-host evidence.
+  user-service-cycle smoke, and `just honey-openxr-fresh-boot-check` is the
+  prepared post-boot capture lane. Fresh-boot and in-goggles first-frame proof
+  remain separate named-host evidence until that target is run after an
+  attended/manual boot.
 - `vr-hardware.yml` should stay opt-in and capability-gated. A green run there
   is strong evidence, but it is still not the same thing as a repeatable named-host
   user session.

--- a/docs/status.md
+++ b/docs/status.md
@@ -20,11 +20,12 @@ Snapshot date: 2026-04-25
 - The active blockers on `honey` are now productization and repeatability, not missing lease support:
   - compositor-side `DP-2` designation and Monado direct-mode settings now both have supported host config surfaces, and `monado-beyond` is installed as a real host package on `honey`
   - the package-default `exwm-vr-monado.service` now runs `/usr/bin/monado-service` without `MONADO_SERVICE_BIN`, and the packaged launcher clears dead `monado_comp_ipc` sockets before launching when no `monado-service` is active
-  - the repo now carries `packaging/scripts/exwm-vr-openxr-smoke`, plus `just honey-openxr-status`, `just honey-openxr-smoke`, and `just honey-openxr-clean-cycle`, so the OpenXR client invocation and clean service-cycle check are repo-owned instead of undocumented SSH one-liners
+  - the repo now carries `packaging/scripts/exwm-vr-openxr-smoke`, plus `just honey-openxr-status`, `just honey-openxr-smoke`, `just honey-openxr-clean-cycle`, and `just honey-openxr-fresh-boot-check`, so the OpenXR client invocation, clean service-cycle check, and post-boot capture lane are repo-owned instead of undocumented SSH one-liners
   - the `exwm-vr-openxr-smoke-client` RPM from GitHub Actions run `24938791255` is now installed on `honey`, and `just honey-openxr-status` resolves the packaged client path `/usr/libexec/exwm-vr/hello_xr -g Vulkan`
   - on `2026-04-25` EDT, three bounded packaged-client smoke passes succeeded in one active user-service session, each selecting Bigscreen Beyond and creating two `3561x3561` eye swapchains through Monado
   - three clean stop/start cycles also succeeded: two from the explicit shell sequence and one through `just honey-openxr-clean-cycle`; `rke2-server` stayed active
-  - this is clean service-cycle repeatability evidence, but it is not yet fresh-boot, in-goggles first-frame, or long-running operator proof
+  - `just honey-openxr-fresh-boot-check` is now prepared for the next attended/manual fresh boot; it does not reboot `honey`, and it has not yet produced fresh-boot evidence
+  - the current proof is clean service-cycle repeatability evidence, but it is not yet fresh-boot, in-goggles first-frame, or long-running operator proof
 - `yoga` now has `exwm-vr-0.5.4-1.el10`, `exwm-vr-compositor-0.5.4-1.el10`, and `exwm-vr-elisp-0.5.4-1.el10` installed.
 - `yoga` validated the earlier named-host package line: the compositor binary links cleanly, a bounded runtime succeeds with `seatd`, and Wayland/DRM/libinput startup is confirmed.
 - The branch-scoped `0.5.4-1.el10` session payload from GitHub Actions run `24768509226` now has both a staged proof and a real installed-package proof on `yoga`; the installed units reached `active` / `active` / `active`, `ewwm-compositor v0.5.4 starting`, `backend: drm`, `ewwm-ipc: connected`, and `ewwm: initialized` without the old ambient dotfile contamination.
@@ -80,7 +81,7 @@ Snapshot date: 2026-04-25
 ## Immediate Priorities
 
 1. Preserve the now-explicit `monado_comp_ipc` cleanup path in the launcher and keep the `honey` OpenXR status wrapper as the safe preflight.
-2. Preserve the new installed `monado-beyond` host lane on `honey` and extend repeatability from clean service cycles to fresh-boot cycles.
+2. Preserve the new installed `monado-beyond` host lane on `honey` and run `just honey-openxr-fresh-boot-check honey 1 20` only after an attended/manual reboot to extend repeatability from clean service cycles to fresh-boot cycles.
 3. Keep using the installed `exwm-vr-openxr-smoke-client` path for honey OpenXR smoke runs and record whether failures are host/substrate, packaging/deployment, or compositor/runtime blockers.
 4. Keep the Rocky base package lane green while leaving Monado, SELinux, and BCI as separate follow-on concerns.
 5. Preserve the now-proven `yoga` package/session lane as the 2D reference host while packaging continues to evolve.

--- a/justfile
+++ b/justfile
@@ -731,6 +731,37 @@ honey-openxr-clean-cycle host="honey" cycles="1" timeout="20":
     )"
     just honey-run "{{host}}" -- "${cmd}"
 
+[group('ci')]
+honey-openxr-fresh-boot-check host="honey" cycles="1" timeout="20":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cycles="{{cycles}}"
+    timeout_seconds="{{timeout}}"
+    if ! [[ "${cycles}" =~ ^[0-9]+$ ]] || (( cycles < 1 )); then
+        echo "ERROR: cycles must be a positive integer" >&2
+        exit 64
+    fi
+    if ! [[ "${timeout_seconds}" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: timeout must be an integer number of seconds" >&2
+        exit 64
+    fi
+    echo "This target does not reboot {{host}}."
+    echo "Run it only after an attended/manual fresh boot has completed."
+    just honey-run "{{host}}" -- 'set -euo pipefail
+    echo "== fresh boot preflight =="
+    echo "host=$(hostname 2>/dev/null || echo unknown)"
+    echo "repo=$(pwd)"
+    echo "head=$(git rev-parse --short HEAD)"
+    echo "boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || echo unknown)"
+    echo "uptime_seconds=$(cut -d" " -f1 /proc/uptime 2>/dev/null || echo unknown)"
+    echo "kernel=$(uname -r)"
+    printf "rke2-server="
+    systemctl is-active rke2-server 2>/dev/null || true
+    printf "rke2-agent="
+    systemctl is-active rke2-agent 2>/dev/null || true
+    ./packaging/scripts/exwm-vr-openxr-smoke --status-only'
+    just honey-openxr-clean-cycle "{{host}}" "${cycles}" "${timeout_seconds}"
+
 # ── nix ────────────────────────────────────────────────
 
 [group('nix')]


### PR DESCRIPTION
## Summary

Adds a repo-owned `honey` post-boot verification lane for the next attended/manual fresh boot.

- adds `just honey-openxr-fresh-boot-check`, which records post-boot host identity, repo head, boot ID, uptime, kernel, `rke2` state, and OpenXR status before delegating to the existing clean-cycle smoke lane
- documents that the target does not reboot `honey` and should only be run after an attended/manual fresh boot
- keeps current claims bounded: clean service-cycle repeatability is proven, fresh-boot and in-goggles first-frame proof are still pending

## Safety Notes

- No reboot is performed by this target.
- No `rke2` stop or restart is performed.
- This PR does not claim fresh-boot evidence yet.

## Validation

- `just --list | rg -n "honey-openxr"`
- `just --dry-run honey-openxr-fresh-boot-check honey 1 20`
- `git diff --check`
- `just truth-lint` (`18/18`)

`JUST_UNSTABLE=1 just --fmt --check` was intentionally not used as a gate because it requests a whole-file formatter migration unrelated to this patch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `honey-openxr-fresh-boot-check` justfile target that records post-boot host identity (hostname, repo HEAD, boot ID, uptime, kernel, rke2 state, OpenXR status) and then delegates to the existing `honey-openxr-clean-cycle` for the packaged smoke run. Five documentation files are updated in parallel to register the new lane and clarify that it requires an attended/manual fresh boot and has not yet produced fresh-boot evidence.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic errors, security issues, or resource-management concerns found.

The new justfile target follows the same input-validation pattern as the existing `honey-openxr-clean-cycle` recipe, the remote script is correctly base64-passed through `honey-run`, quoting inside the single-quoted block is sound, and the documentation additions are accurate and internally consistent. No P0 or P1 findings.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| justfile | Adds `honey-openxr-fresh-boot-check` recipe that validates inputs, runs a remote preflight (host identity, boot ID, uptime, kernel, rke2 state, OpenXR status), then delegates to `honey-openxr-clean-cycle`; implementation is consistent with existing `honey-openxr-clean-cycle` patterns. |
| docs/honey-substrate-proof-2026-04-22.md | Adds documentation for the new `honey-openxr-fresh-boot-check` target: lists it in the remote helper inventory, describes its behavior and limitations, and updates the next-steps checklist to reference it. |
| docs/hygiene-minisprint-2026-04-25.md | Updates sprint notes to reference the new `honey-openxr-fresh-boot-check` lane in the repeatability checklist and current-facts section. |
| docs/remote-proof-lanes.md | Adds `honey-openxr-fresh-boot-check` to the remote-dev lane list and documents that it is a post-boot-only target, consistent with safety notes in the PR. |
| docs/status.md | Updates the snapshot to include the new target in the repo-owned command list and clarifies that fresh-boot evidence has not yet been produced. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add honey fresh boot check lane"](https://github.com/jesssullivan/xoxdwm/commit/d46d0076f54348374b9394948b311420bfdfec53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29738382)</sub>

<!-- /greptile_comment -->