### PR TITLE
Add honey fresh-boot evidence template

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ As of 2026-04-26:
 - [Yoga Session Proof](docs/yoga-session-proof-2026-04-22.md)
 - [Honey Substrate Proof](docs/honey-substrate-proof-2026-04-22.md)
 - [Honey Fresh-Boot Runbook](docs/honey-fresh-boot-runbook-2026-04-26.md)
+- [Honey Fresh-Boot Evidence Template](docs/honey-fresh-boot-evidence-template.md)
 - [Status](docs/status.md)
 - [Q2 2026 Roadmap](docs/roadmap-2026-q2.md)
 - [Installation Quickstart](docs/installation-quickstart.md)

--- a/docs/honey-fresh-boot-evidence-template.md
+++ b/docs/honey-fresh-boot-evidence-template.md
@@ -1,0 +1,135 @@
+# `honey` Fresh-Boot Evidence Template
+
+Use this template after running
+[honey-fresh-boot-runbook-2026-04-26.md](honey-fresh-boot-runbook-2026-04-26.md).
+It is meant for GitHub issue `#20`, Linear `TIN-346`, and any follow-up doc
+promotion.
+
+Do not use this template to record reset, PSU, BIOS, SMI, or display-topology
+truth as if it were XoxdWM-owned evidence. Link those Dell-7810 artifacts here
+and keep this packet focused on downstream compositor/OpenXR behavior.
+
+## Run Identity
+
+- Date/time UTC:
+- Date/time local:
+- Operator on `neo`:
+- Lab operator at `honey`:
+- XoxdWM commit:
+- `honey` commit:
+- GitHub issue:
+- Linear issue:
+
+## Dell-7810 Host Evidence Links
+
+- Dell reset/power/display artifact:
+- Boot action type:
+  - warm reboot / hard reset / power cycle / other
+- Dell HDMI management display:
+  - connected / disconnected
+  - result:
+- Bigscreen Beyond DP path:
+  - connected / disconnected
+  - result:
+- Tailscale return:
+  - yes / no
+- Local IPv4 return:
+  - yes / no
+- Host/kernel notes from Dell-7810:
+
+## XoxdWM Pre-Boot Baseline
+
+Paste the pre-boot status-only output:
+
+```text
+```
+
+Required fields:
+
+- pre-boot `boot_id`:
+- pre-boot `rke2-server`:
+- pre-boot `rke2-agent`:
+- pre-boot OpenXR client:
+- pre-boot IPC/socket state:
+
+## Post-Boot Fresh-Boot Check
+
+Command:
+
+```sh
+just honey-openxr-fresh-boot-check honey 1 20
+```
+
+Paste the post-boot output:
+
+```text
+```
+
+Required fields:
+
+- post-boot `boot_id`:
+- boot ID changed:
+  - yes / no
+- `honey` repo head:
+- `rke2-server` after check:
+- `rke2-agent` after check:
+- OpenXR client:
+- runtime:
+- headset:
+- eye swapchain size:
+- `openxr_smoke`:
+
+## In-Goggles Observation
+
+CLI smoke is not first-frame proof by itself.
+
+- Human observed visible frame:
+  - yes / no / not observed
+- Observer:
+- Headset/display note:
+- If no visible frame, classify as product/visual even if CLI smoke passed.
+
+## Classification
+
+Select exactly one primary classification:
+
+- Pass: fresh-boot OpenXR smoke
+- Host/substrate blocker
+- Packaging/deployment blocker
+- Compositor/runtime blocker
+- Product/visual blocker
+- Inconclusive / rerun needed
+
+Rationale:
+
+## Tracker Comment Draft
+
+```markdown
+Fresh-boot evidence run:
+
+- XoxdWM commit:
+- honey commit:
+- Dell artifact:
+- boot action:
+- boot ID changed:
+- rke2-server after check:
+- packaged client:
+- runtime/headset:
+- eye swapchains:
+- openxr_smoke:
+- in-goggles frame:
+- classification:
+
+Notes:
+```
+
+## Promotion Decision
+
+- Update [support-matrix.md](support-matrix.md):
+  - yes / no
+- Update [status.md](status.md):
+  - yes / no
+- Keep as issue-only evidence:
+  - yes / no
+- Reason:
+

--- a/docs/honey-fresh-boot-runbook-2026-04-26.md
+++ b/docs/honey-fresh-boot-runbook-2026-04-26.md
@@ -8,6 +8,7 @@ check without moving reset, power, or display-topology authority out of
 Read this with:
 
 - [honey-substrate-proof-2026-04-22.md](honey-substrate-proof-2026-04-22.md)
+- [honey-fresh-boot-evidence-template.md](honey-fresh-boot-evidence-template.md)
 - [remote-proof-lanes.md](remote-proof-lanes.md)
 - [support-matrix.md](support-matrix.md)
 - [status.md](status.md)
@@ -138,10 +139,12 @@ Classify the first failure before rerunning:
 
 After the run:
 
+- Fill out [honey-fresh-boot-evidence-template.md](honey-fresh-boot-evidence-template.md)
+  with the Dell artifact links, pre/post boot IDs, OpenXR output, and
+  classification.
 - Comment on GitHub issue `#20` with the log path or selected output.
 - Update Linear `TIN-346`.
 - If the blocker is host/reset/display/power, update the appropriate Dell-7810
   tracker instead of promoting XoxdWM support.
 - Update [support-matrix.md](support-matrix.md) only after the evidence passes
   and the status label remains honest.
-

--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -12,6 +12,8 @@ runtime claim.
 
 For the next attended `honey` fresh-boot proof, use
 [honey-fresh-boot-runbook-2026-04-26.md](honey-fresh-boot-runbook-2026-04-26.md).
+Record the result with
+[honey-fresh-boot-evidence-template.md](honey-fresh-boot-evidence-template.md).
 
 ## Core Distinction
 


### PR DESCRIPTION
## Summary

Adds a paste-ready evidence template for the attended `honey` fresh-boot lane.

- adds `docs/honey-fresh-boot-evidence-template.md`
- links it from README, `remote-proof-lanes.md`, and the attended fresh-boot runbook
- keeps Dell reset/power/display facts as linked Dell-7810 evidence, not XoxdWM-owned product proof
- separates pre-boot baseline, post-boot OpenXR output, in-goggles observation, classification, tracker comment draft, and promotion decision

## Boundaries

- This PR performs no host action and no reboot.
- This does not produce fresh-boot evidence.
- `rke2` remains out of scope for stop/restart experiments.

## Validation

- `git diff --check`
- `just truth-lint` (`18/18`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a paste-ready evidence template (`docs/honey-fresh-boot-evidence-template.md`) for the attended `honey` fresh-boot lane and links it from `README.md`, `remote-proof-lanes.md`, and the fresh-boot runbook. The changes are documentation-only with no code, system calls, or resource management involved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only changes with no code impact.

All four changed files are Markdown documentation. No C, Rust, or any executable code is touched, so none of the memory-safety, system-call, or resource-cleanup rules apply. Links use correct relative paths consistent with the existing doc style, sections are logically complete, and no issues were found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/honey-fresh-boot-evidence-template.md | New evidence template with well-structured sections for run identity, Dell-7810 host links, pre/post-boot baselines, in-goggles observation, classification, tracker comment draft, and promotion decision; no issues found. |
| README.md | Adds a single link to the new evidence template in the docs list; correct relative path. |
| docs/honey-fresh-boot-runbook-2026-04-26.md | Adds reference to the evidence template in the 'Read this with' list and a post-run fill-out instruction; removes trailing blank line. |
| docs/remote-proof-lanes.md | Adds two lines directing readers to record results with the evidence template; no issues. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add honey fresh boot evidence temp..."](https://github.com/jesssullivan/xoxdwm/commit/a0255aa81f8f425ca1cab8e49738285c75b52f84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29770050)</sub>

<!-- /greptile_comment -->