### PR TITLE
native-authority: truth and tracker foundation

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -10,6 +10,16 @@
     "description": "Work required for the named-host MVP"
   },
   {
+    "name": "epic",
+    "color": "5319e7",
+    "description": "Durable milestone-level tracker item"
+  },
+  {
+    "name": "product-gate",
+    "color": "b60205",
+    "description": "Claim-gating issue tied to product truth"
+  },
+  {
     "name": "vr",
     "color": "1d76db",
     "description": "VR compositor, OpenXR, and HMD integration work"

--- a/docs/research/cosmic-reference-pins-2026-05-10.md
+++ b/docs/research/cosmic-reference-pins-2026-05-10.md
@@ -1,0 +1,50 @@
+# COSMIC Reference Pins - 2026-05-10
+
+This is a research ledger for native XoxdWM authority work. It does not vendor
+COSMIC code, add a COSMIC runtime dependency, or turn COSMIC packaging into a
+current product target.
+
+## Epoch Pin
+
+- Upstream: `pop-os/cosmic-epoch`
+- Release: `epoch-1.0.12`
+- Release URL: <https://github.com/pop-os/cosmic-epoch/releases/tag/epoch-1.0.12>
+- Published: 2026-05-05 21:23:48 UTC
+- Annotated tag: `e0246cb61c4570464597727645b0684f5cc440a8`
+- Checked-out commit: `4412bb00d7b9924131d49738164e80597c041ea6`
+- Release note items relevant to XoxdWM: Smithay update in `cosmic-comp`,
+  resume DPMS cleanup, Rust 1.93 toolchain bump, and dependency updates across
+  the Epoch graph.
+
+## Module Commits Worth Studying
+
+| Module | Commit | XoxdWM relevance |
+| --- | --- | --- |
+| `cosmic-comp` | `b5a1a6d3179810627fa0bffac7bd5d78c7df4fa0` | Smithay compositor policy, workspace/layout/session boundaries. |
+| `cosmic-session` | `17cf4485a917c5e7490c0e1a26cdf348f06bf486` | Session startup, lock/logout boundary, environment handoff. |
+| `cosmic-idle` | `c95d066b5b640509a6369634b669ca60dc50e168` | Idle supervision and DPMS-related behavior. |
+| `cosmic-randr` | `6e8e795970fa06d434af22775e415b517f7552d3` | Output configuration patterns and user-facing display state. |
+| `cosmic-panel` | `2358f0473bf68b79f54a0906994a218de211de34` | App-layer shell client behavior, not compositor authority. |
+| `cosmic-launcher` | `296e5cb66c77159840d2039540ede315bcd51ab0` | Launcher UX as client surface; XoxdWM keeps launch authority in native config. |
+| `cosmic-settings-daemon` | `716da6d6af0b252e2f78aba2ad72ee19ae0241e0` | Settings daemon split from compositor policy. |
+| `xdg-desktop-portal-cosmic` | `db8ec7cf496ed0f2028c67f4eec7ffdc2cbcf145` | Portal boundary reference for later capture/session work. |
+
+## Mapping To XoxdWM Trackers
+
+| XoxdWM issue | COSMIC reference area | Boundary |
+| --- | --- | --- |
+| #51, #54, #59, #65 | `cosmic-comp`, `cosmic-settings-daemon` | Native config and reload authority stay in Rust. |
+| #60, #61 | `cosmic-comp`, `cosmic-workspaces-epoch` | Study layout/workspace behavior; do not copy implementation. |
+| #67, #70 | `cosmic-session`, `cosmic-launcher` | Startup and launch targets stay configured native policy. |
+| #68, #69 | `cosmic-session`, `cosmic-idle` | Lock/logout/idle/DPMS boundaries stay narrow and explicit. |
+| #71, #72, #73 | `cosmic-panel`, applets | Emacs/eGreg remains an app-layer/control client, analogous to shell clients. |
+
+## Explicit Non-Goals
+
+- Do not vendor COSMIC source into this repository.
+- Do not pin arbitrary module `HEAD` commits outside the coherent Epoch release
+  graph for authority work.
+- Do not use COSMIC visual assets, app examples, or shell UX as product proof
+  for XoxdWM.
+- Do not promote this ledger beyond research/design evidence until a separate
+  runtime or packaging task exists.

--- a/docs/research/native-authority-pr-split-manifest-2026-05-10.md
+++ b/docs/research/native-authority-pr-split-manifest-2026-05-10.md
@@ -1,0 +1,187 @@
+# Native Authority PR Split Manifest - 2026-05-10
+
+This manifest maps the current native XoxdWM authority worktree into the
+review stack for #45. GitHub issues stay open until their implementing PR
+merges; Linear TIN-1086 receives one breadcrumb per PR.
+
+## 1. Truth + Tracker Foundation
+
+Covers #52, #58, #66 and shared tracker/docs guardrails.
+
+- `.github/labels.json`
+- `docs/api-reference.md`
+- `docs/developer-guide.md`
+- `docs/feature-matrix.md`
+- `docs/installation-quickstart.md`
+- `docs/research/cosmic-reference-pins-2026-05-10.md`
+- `docs/research/native-authority-pr-split-manifest-2026-05-10.md`
+- `docs/status.md` native-authority/support truth hunks
+- `docs/support-matrix.md` native-authority/support truth hunks
+- `docs/user-guide.md` native-config authority hunks
+- `test/truth-surface-test.el`
+- `test/ipc-contract-test.el`
+- `test/native-authority-test.el`
+- `justfile` truth/static-test target hunks
+
+Focused checks:
+
+- `just truth-lint`
+- `just ipc-contract-test`
+- `just native-authority-test`
+
+## 2. Native Config + IPC Authority Base
+
+Covers #51, #54, #55, #59, #64, #65.
+
+- `compositor/Cargo.toml`
+- `compositor/src/config.rs`
+- `compositor/src/input.rs`
+- `compositor/src/ipc/dispatch.rs` app-launch, config-reload, workspace, layout, key-action, and command-list hunks
+- `compositor/src/ipc/recorder.rs`
+- `compositor/src/ipc/server.rs`
+- `compositor/src/main.rs`
+- `compositor/src/state.rs` config, workspace, focus, key-action, and launch hunks
+- `compositor/src/backend/headless.rs`
+- `compositor/src/backend/mod.rs`
+- `docs/ipc-protocol.md` app-launch/config-reload/workspace/layout hunks
+- `test/v041-wm-commands-test.el`
+
+Focused checks:
+
+- `cargo fmt --manifest-path compositor/Cargo.toml --check`
+- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`
+- `just ipc-contract-test`
+
+## 3. Native Runtime Policy
+
+Covers #60, #61, #67, #68, #69, #70.
+
+- `compositor/src/autotype.rs`
+- `compositor/src/backend/drm.rs`
+- `compositor/src/backend/winit.rs`
+- `compositor/src/handlers/compositor.rs`
+- `compositor/src/handlers/dpms.rs`
+- `compositor/src/handlers/layer_shell.rs`
+- `compositor/src/handlers/mod.rs`
+- `compositor/src/handlers/output_management.rs`
+- `compositor/src/handlers/pointer_constraints.rs`
+- `compositor/src/handlers/seat.rs`
+- `compositor/src/handlers/xdg_activation.rs`
+- `compositor/src/handlers/xdg_shell.rs`
+- `compositor/src/handlers/xwayland.rs`
+- `compositor/src/input_source.rs`
+- `compositor/src/lib.rs`
+- `compositor/src/secure_input.rs`
+- `compositor/src/state.rs` layout reflow, workspace visibility, autostart, session, idle, and DPMS hunks
+- `compositor/tests/full_stack_integration.rs`
+- `compositor/tests/headless_integration.rs`
+- `docs/ipc-protocol.md` autostart/session/idle hunks
+- `test/v040-focus-cursor-test.el`
+
+Focused checks:
+
+- `cargo fmt --manifest-path compositor/Cargo.toml --check`
+- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`
+- `just native-authority-test`
+
+## 4. Emacs/eGreg App-Layer Bridge
+
+Covers #71, #72, #73.
+
+- `lisp/vr/ewwm-floating.el`
+- `lisp/vr/ewwm-input.el`
+- `lisp/vr/ewwm-ipc.el`
+- `lisp/vr/ewwm-launch.el`
+- `lisp/vr/ewwm-layout.el`
+- `lisp/vr/ewwm-manage.el`
+- `lisp/vr/ewwm-session.el`
+- `lisp/vr/ewwm.el`
+- `docs/ipc-protocol.md` connected-client compatibility hunks
+
+Focused checks:
+
+- `just ipc-contract-test`
+- `just test`
+
+## 5. Runtime Proof + Packaging Boundary
+
+Covers #53, #56, #62, #63.
+
+- `justfile` native-authority proof, boot-without-Emacs smoke, and package assertion hunks
+- `packaging/rpm/exwm-vr.spec`
+- `packaging/scripts/boot-without-emacs-smoke`
+- `packaging/scripts/xoxdwm-native-authority-proof`
+- `packaging/sway/config`
+- `packaging/sway/status.sh`
+- `docs/status.md` no-product-proof/native-proof boundary hunks
+- `docs/support-matrix.md` native WM authority support row hunks
+- `docs/user-guide.md` JSON-backed native-config reference hunks
+
+Focused checks:
+
+- `just package-no-default-lisp-core-assert`
+- `just boot-without-emacs-smoke 1`
+- `just native-authority-test`
+
+## 6. Honey P4 / XR Evidence Lane
+
+Covers #49, #57 and Honey-specific proof helpers.
+
+- `README.md`
+- `compositor/src/handlers/drm_lease.rs`
+- `compositor/src/render.rs`
+- `compositor/src/vr/attention.rs`
+- `compositor/src/vr/bci_state.rs`
+- `compositor/src/vr/beyond_hid.rs`
+- `compositor/src/vr/blink_wink.rs`
+- `compositor/src/vr/drm_lease.rs`
+- `compositor/src/vr/eye_tracking.rs`
+- `compositor/src/vr/fatigue.rs`
+- `compositor/src/vr/fatigue_eeg.rs`
+- `compositor/src/vr/follow_mode.rs`
+- `compositor/src/vr/frame_timing.rs`
+- `compositor/src/vr/gaze_focus.rs`
+- `compositor/src/vr/gaze_scroll.rs`
+- `compositor/src/vr/gaze_zone.rs`
+- `compositor/src/vr/gesture.rs`
+- `compositor/src/vr/gpu_power.rs`
+- `compositor/src/vr/hand_tracking.rs`
+- `compositor/src/vr/link_hints.rs`
+- `compositor/src/vr/mod.rs`
+- `compositor/src/vr/motor_imagery.rs`
+- `compositor/src/vr/openxr_state.rs`
+- `compositor/src/vr/overlay.rs`
+- `compositor/src/vr/p300.rs`
+- `compositor/src/vr/radial_menu.rs`
+- `compositor/src/vr/scene.rs`
+- `compositor/src/vr/ssvep.rs`
+- `compositor/src/vr/stub.rs`
+- `compositor/src/vr/texture.rs`
+- `compositor/src/vr/transient_3d.rs`
+- `compositor/src/vr/virtual_keyboard.rs`
+- `compositor/src/vr/vr_interaction.rs`
+- `compositor/src/vr/vr_renderer.rs`
+- `docs/honey-fresh-boot-evidence-template.md`
+- `docs/honey-fresh-boot-runbook-2026-04-26.md`
+- `docs/research/fpga-dsc-verification.md`
+- `docs/research/honey-kernel-dsc-truth-2026-05-10.md`
+- `docs/status.md` Honey topology/P3/P4 hunks
+- `docs/support-matrix.md` Honey proof-ladder/topology hunks
+- `docs/user-guide.md` Honey HMD connector hunks
+- `justfile` Honey smoke/status/proof hunks
+- `packaging/scripts/beyond-power-on`
+- `packaging/scripts/exwm-vr-hmd-connector`
+- `packaging/scripts/exwm-vr-kernel-dsc-truth`
+- `packaging/scripts/exwm-vr-monado-launch`
+- `packaging/scripts/exwm-vr-openxr-smoke`
+- `packaging/scripts/exwm-vr-setup`
+- `patches/amdgpu-dsc-pps-debugfs.patch`
+- `test/honey-display-regression-test.el`
+- `test/honey-substrate-test.el`
+- `test/v050-vr-renderer-test.el`
+
+Focused checks:
+
+- `just truth-lint`
+- `just test`
+- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`


### PR DESCRIPTION
Refs #45. Issue set: #52, #58, #66.

## Scope
- Adds tracker labels for durable epics and product gates.
- Adds the local stacked-PR split manifest for the native authority work.
- Pins the COSMIC epoch-1.0.12 reference ledger as research-only evidence, with no vendored COSMIC code.

## Validation
- Verified on final stack tip: git diff --check main...codex/honey-p4-xr-evidence
- Verified on final stack tip: just truth-lint
- Verified on final stack tip: just test

Issue closure should happen only after the implementing PR has merged.