### PR TITLE
native-authority: config and IPC base

### DIFF
--- a/compositor/Cargo.toml
+++ b/compositor/Cargo.toml
@@ -11,9 +11,12 @@ name = "ewwm-compositor"
 path = "src/main.rs"
 
 [features]
-default = ["full-backend"]
+default = []
 xwayland = ["smithay/xwayland"]
-full-backend = [    # enables DRM/winit backends (requires libseat, libinput, DRM, udev)
+# Portable default builds use the headless backend. Linux host/session builds
+# must opt into full-backend explicitly because it requires Wayland/DRM system
+# libraries that are not available on Darwin developer hosts.
+full-backend = [
     "xwayland",
     "smithay/backend_drm",
     "smithay/backend_gbm",
@@ -22,7 +25,7 @@ full-backend = [    # enables DRM/winit backends (requires libseat, libinput, DR
     "smithay/backend_udev",
     "smithay/backend_winit",
 ]
-vr = ["openxrs", "glow", "khronos-egl"]    # enables OpenXR VR runtime + GL rendering
+vr = ["openxrs", "glow", "khronos-egl"] # enables OpenXR VR runtime + GL rendering
 
 [dependencies]
 smithay = { version = "0.7", default-features = false, features = [

--- a/compositor/src/backend/headless.rs
+++ b/compositor/src/backend/headless.rs
@@ -4,14 +4,12 @@
 //! configurable poll intervals, graceful signal handling, and
 //! periodic status logging.
 
-use crate::{ipc, state::EwwmState};
 use super::IpcConfig;
+use crate::config::CompositorConfig;
+use crate::{ipc, state::EwwmState};
 use smithay::{
     output::{Mode as OutputMode, Output, PhysicalProperties, Subpixel},
-    reexports::{
-        calloop::EventLoop,
-        wayland_server::Display,
-    },
+    reexports::{calloop::EventLoop, wayland_server::Display},
     utils::Transform,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -63,12 +61,7 @@ impl HeadlessConfig {
 }
 
 /// Create a virtual output with the given index and resolution.
-fn create_virtual_output(
-    state: &mut EwwmState,
-    index: u32,
-    width: i32,
-    height: i32,
-) -> Output {
+fn create_virtual_output(state: &mut EwwmState, index: u32, width: i32, height: i32) -> Output {
     let mode = OutputMode {
         size: (width, height).into(),
         refresh: 60_000,
@@ -90,9 +83,21 @@ fn create_virtual_output(
     );
     output.set_preferred(mode);
     state.space.map_output(&output, ((index as i32) * width, 0));
+    let mut output_config =
+        crate::handlers::output_management::OutputConfig::new(format!("headless-{}", index));
+    output_config.x = (index as i32) * width;
+    output_config.width = width;
+    output_config.height = height;
+    output_config.refresh = 60_000;
+    state
+        .output_management_state
+        .upsert_detected_output(output_config);
     info!(
         "Created virtual output headless-{}: {}x{} at offset ({}, 0)",
-        index, width, height, (index as i32) * width
+        index,
+        width,
+        height,
+        (index as i32) * width
     );
     output
 }
@@ -121,11 +126,13 @@ pub fn run(
     exit_after: Option<u64>,
     ipc_config: IpcConfig,
     config: HeadlessConfig,
+    compositor_config: CompositorConfig,
 ) -> anyhow::Result<()> {
     let mut event_loop = EventLoop::<EwwmState>::try_new()?;
     let mut display = Display::<EwwmState>::new()?;
 
-    let mut state = EwwmState::new(&mut display, event_loop.handle());
+    let mut state =
+        EwwmState::new_with_config(&mut display, event_loop.handle(), compositor_config);
 
     // Store headless config in state for IPC queries
     state.headless_active = true;

--- a/compositor/src/backend/mod.rs
+++ b/compositor/src/backend/mod.rs
@@ -42,9 +42,9 @@ pub fn run(
     };
     match backend {
         #[cfg(feature = "full-backend")]
-        BackendType::Winit => winit::run(socket_name, ipc, compositor_config),
+        BackendType::Winit => winit::run(socket_name, ipc),
         #[cfg(feature = "full-backend")]
-        BackendType::Drm => drm::run(socket_name, ipc, compositor_config),
+        BackendType::Drm => drm::run(socket_name, ipc),
         BackendType::Headless => headless::run(
             socket_name,
             headless_exit_after,

--- a/compositor/src/backend/mod.rs
+++ b/compositor/src/backend/mod.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::config::CompositorConfig;
+
 #[cfg(feature = "full-backend")]
 pub mod drm;
 pub mod headless;
@@ -32,6 +34,7 @@ pub fn run(
     headless_config: headless::HeadlessConfig,
     ipc_socket: Option<PathBuf>,
     ipc_trace: bool,
+    compositor_config: CompositorConfig,
 ) -> anyhow::Result<()> {
     let ipc = IpcConfig {
         socket_path: ipc_socket,
@@ -39,9 +42,15 @@ pub fn run(
     };
     match backend {
         #[cfg(feature = "full-backend")]
-        BackendType::Winit => winit::run(socket_name, ipc),
+        BackendType::Winit => winit::run(socket_name, ipc, compositor_config),
         #[cfg(feature = "full-backend")]
-        BackendType::Drm => drm::run(socket_name, ipc),
-        BackendType::Headless => headless::run(socket_name, headless_exit_after, ipc, headless_config),
+        BackendType::Drm => drm::run(socket_name, ipc, compositor_config),
+        BackendType::Headless => headless::run(
+            socket_name,
+            headless_exit_after,
+            ipc,
+            headless_config,
+            compositor_config,
+        ),
     }
 }

--- a/compositor/src/config.rs
+++ b/compositor/src/config.rs
@@ -427,12 +427,12 @@ fn unquote(s: &str) -> String {
 fn parse_string_list(s: &str) -> Vec<String> {
     let trimmed = s.trim();
     let body = if trimmed.starts_with('[') && trimmed.ends_with(']') {
-        &trimmed[1..trimmed.len() - 1]
+        trimmed[1..trimmed.len() - 1].to_string()
     } else {
-        trimmed
+        unquote(trimmed)
     };
     body.split(',')
-        .map(unquote)
+        .map(|item| unquote(item.trim()))
         .map(|item| item.trim().to_string())
         .filter(|item| !item.is_empty())
         .collect()
@@ -566,6 +566,14 @@ mod tests {
         let cfg = CompositorConfig::parse_json(json).unwrap();
         assert_eq!(cfg.extra.get("my_custom_key").unwrap(), "my_value");
         assert_eq!(cfg.extra.get("another_key").unwrap(), "42");
+    }
+
+    #[test]
+    fn test_string_list_accepts_json_arrays() {
+        assert_eq!(
+            parse_string_list(r#"["terminal", "browser"]"#),
+            vec!["terminal", "browser"]
+        );
     }
 
     #[test]

--- a/compositor/src/config.rs
+++ b/compositor/src/config.rs
@@ -28,6 +28,18 @@ pub struct CompositorConfig {
     pub cursor_theme: String,
     pub cursor_size: u32,
 
+    // Workspace policy
+    pub workspace_count: usize,
+    pub active_workspace: usize,
+    pub layout_mode: String,
+    pub key_actions: HashMap<String, String>,
+    pub app_launch_commands: HashMap<String, String>,
+    pub autostart_enabled: bool,
+    pub autostart_targets: Vec<String>,
+    pub session_lock_command: Option<String>,
+    pub session_idle_enabled: bool,
+    pub session_idle_command: Option<String>,
+
     // VR
     pub vr_enabled: bool,
     pub vr_runtime: String,
@@ -57,6 +69,16 @@ impl Default for CompositorConfig {
             default_scale: 1.0,
             cursor_theme: "Adwaita".to_string(),
             cursor_size: 24,
+            workspace_count: 4,
+            active_workspace: 0,
+            layout_mode: "tiling".to_string(),
+            key_actions: default_key_actions(),
+            app_launch_commands: HashMap::new(),
+            autostart_enabled: false,
+            autostart_targets: Vec::new(),
+            session_lock_command: None,
+            session_idle_enabled: false,
+            session_idle_command: None,
             vr_enabled: false,
             vr_runtime: "monado".to_string(),
             follow_policy: "threshold-only".to_string(),
@@ -86,13 +108,29 @@ impl CompositorConfig {
         PathBuf::from(config_home).join("exwm-vr/compositor.json")
     }
 
+    /// Return the configured IPC socket as a path, if one was supplied.
+    pub fn ipc_socket_pathbuf(&self) -> Option<PathBuf> {
+        self.ipc_socket_path.as_ref().map(PathBuf::from)
+    }
+
+    /// Return a nonzero workspace count for runtime state.
+    pub fn normalized_workspace_count(&self) -> usize {
+        self.workspace_count.max(1)
+    }
+
+    /// Return an active workspace index bounded by the configured count.
+    pub fn normalized_active_workspace(&self) -> usize {
+        self.active_workspace
+            .min(self.normalized_workspace_count().saturating_sub(1))
+    }
+
     /// Load configuration from a JSON file.
     ///
     /// Uses a simple line-based parser that handles flat JSON objects.
     /// Unknown keys are stored in `extra`.
     pub fn load_from_file(path: &str) -> Result<Self, String> {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("cannot read {}: {}", path, e))?;
+        let content =
+            fs::read_to_string(path).map_err(|e| format!("cannot read {}: {}", path, e))?;
         Self::parse_json(&content)
     }
 
@@ -101,7 +139,10 @@ impl CompositorConfig {
     pub fn load_or_default() -> Self {
         let path = Self::config_path();
         if !path.exists() {
-            info!("config: no config file at {}, using defaults", path.display());
+            info!(
+                "config: no config file at {}, using defaults",
+                path.display()
+            );
             return Self::default();
         }
         match Self::load_from_file(&path.to_string_lossy()) {
@@ -110,7 +151,11 @@ impl CompositorConfig {
                 cfg
             }
             Err(e) => {
-                warn!("config: failed to parse {}: {} (using defaults)", path.display(), e);
+                warn!(
+                    "config: failed to parse {}: {} (using defaults)",
+                    path.display(),
+                    e
+                );
                 Self::default()
             }
         }
@@ -129,49 +174,72 @@ impl CompositorConfig {
                 "log_level" => cfg.log_level = unquote(val),
                 "ipc_socket_path" => cfg.ipc_socket_path = Some(unquote(val)),
                 "default_scale" => {
-                    cfg.default_scale = val.parse().map_err(|_| {
-                        format!("invalid default_scale: {}", val)
-                    })?;
+                    cfg.default_scale = val
+                        .parse()
+                        .map_err(|_| format!("invalid default_scale: {}", val))?;
                 }
                 "cursor_theme" => cfg.cursor_theme = unquote(val),
                 "cursor_size" => {
-                    cfg.cursor_size = val.parse().map_err(|_| {
-                        format!("invalid cursor_size: {}", val)
-                    })?;
+                    cfg.cursor_size = val
+                        .parse()
+                        .map_err(|_| format!("invalid cursor_size: {}", val))?;
                 }
+                "workspace_count" => {
+                    cfg.workspace_count = val
+                        .parse()
+                        .map_err(|_| format!("invalid workspace_count: {}", val))?;
+                }
+                "active_workspace" => {
+                    cfg.active_workspace = val
+                        .parse()
+                        .map_err(|_| format!("invalid active_workspace: {}", val))?;
+                }
+                "layout_mode" => cfg.layout_mode = unquote(val),
+                "autostart_enabled" => cfg.autostart_enabled = val == "true",
+                "autostart_targets" => cfg.autostart_targets = parse_string_list(val),
+                "session_lock_command" => cfg.session_lock_command = Some(unquote(val)),
+                "session_idle_enabled" => cfg.session_idle_enabled = val == "true",
+                "session_idle_command" => cfg.session_idle_command = Some(unquote(val)),
                 "vr_enabled" => cfg.vr_enabled = val == "true",
                 "vr_runtime" => cfg.vr_runtime = unquote(val),
                 "follow_policy" => cfg.follow_policy = unquote(val),
                 "follow_h_fov" => {
-                    cfg.follow_h_fov = val.parse().map_err(|_| {
-                        format!("invalid follow_h_fov: {}", val)
-                    })?;
+                    cfg.follow_h_fov = val
+                        .parse()
+                        .map_err(|_| format!("invalid follow_h_fov: {}", val))?;
                 }
                 "follow_v_fov" => {
-                    cfg.follow_v_fov = val.parse().map_err(|_| {
-                        format!("invalid follow_v_fov: {}", val)
-                    })?;
+                    cfg.follow_v_fov = val
+                        .parse()
+                        .map_err(|_| format!("invalid follow_v_fov: {}", val))?;
                 }
                 "follow_speed" => {
-                    cfg.follow_speed = val.parse().map_err(|_| {
-                        format!("invalid follow_speed: {}", val)
-                    })?;
+                    cfg.follow_speed = val
+                        .parse()
+                        .map_err(|_| format!("invalid follow_speed: {}", val))?;
                 }
                 "passthrough_blend_mode" => cfg.passthrough_blend_mode = unquote(val),
                 "gpu_auto_vr_boost" => cfg.gpu_auto_vr_boost = val == "true",
                 "gpu_power_profile" => cfg.gpu_power_profile = unquote(val),
                 "overlay_max_count" => {
-                    cfg.overlay_max_count = val.parse().map_err(|_| {
-                        format!("invalid overlay_max_count: {}", val)
-                    })?;
+                    cfg.overlay_max_count = val
+                        .parse()
+                        .map_err(|_| format!("invalid overlay_max_count: {}", val))?;
                 }
                 "overlay_default_alpha" => {
-                    cfg.overlay_default_alpha = val.parse().map_err(|_| {
-                        format!("invalid overlay_default_alpha: {}", val)
-                    })?;
+                    cfg.overlay_default_alpha = val
+                        .parse()
+                        .map_err(|_| format!("invalid overlay_default_alpha: {}", val))?;
                 }
                 _ => {
-                    cfg.extra.insert(key.clone(), unquote(val));
+                    if let Some(name) = key.strip_prefix("key_action.") {
+                        cfg.key_actions.insert(name.to_string(), unquote(val));
+                    } else if let Some(name) = key.strip_prefix("app_launch.") {
+                        cfg.app_launch_commands
+                            .insert(name.to_string(), unquote(val));
+                    } else {
+                        cfg.extra.insert(key.clone(), unquote(val));
+                    }
                 }
             }
         }
@@ -191,23 +259,52 @@ impl CompositorConfig {
             format!("  \"default_scale\": {}", self.default_scale),
             format!("  \"cursor_theme\": \"{}\"", self.cursor_theme),
             format!("  \"cursor_size\": {}", self.cursor_size),
+            format!("  \"workspace_count\": {}", self.workspace_count),
+            format!("  \"active_workspace\": {}", self.active_workspace),
+            format!("  \"layout_mode\": \"{}\"", self.layout_mode),
+            format!("  \"autostart_enabled\": {}", self.autostart_enabled),
+            format!(
+                "  \"autostart_targets\": \"{}\"",
+                self.autostart_targets.join(",")
+            ),
+            match &self.session_lock_command {
+                Some(command) => format!("  \"session_lock_command\": \"{}\"", command),
+                None => "  \"session_lock_command\": null".to_string(),
+            },
+            format!("  \"session_idle_enabled\": {}", self.session_idle_enabled),
+            match &self.session_idle_command {
+                Some(command) => format!("  \"session_idle_command\": \"{}\"", command),
+                None => "  \"session_idle_command\": null".to_string(),
+            },
             format!("  \"vr_enabled\": {}", self.vr_enabled),
             format!("  \"vr_runtime\": \"{}\"", self.vr_runtime),
             format!("  \"follow_policy\": \"{}\"", self.follow_policy),
             format!("  \"follow_h_fov\": {}", self.follow_h_fov),
             format!("  \"follow_v_fov\": {}", self.follow_v_fov),
             format!("  \"follow_speed\": {}", self.follow_speed),
-            format!("  \"passthrough_blend_mode\": \"{}\"", self.passthrough_blend_mode),
+            format!(
+                "  \"passthrough_blend_mode\": \"{}\"",
+                self.passthrough_blend_mode
+            ),
             format!("  \"gpu_auto_vr_boost\": {}", self.gpu_auto_vr_boost),
             format!("  \"gpu_power_profile\": \"{}\"", self.gpu_power_profile),
             format!("  \"overlay_max_count\": {}", self.overlay_max_count),
-            format!("  \"overlay_default_alpha\": {}", self.overlay_default_alpha),
+            format!(
+                "  \"overlay_default_alpha\": {}",
+                self.overlay_default_alpha
+            ),
         ];
         s.push_str(&fields.join(",\n"));
         if !self.extra.is_empty() {
             for (k, v) in &self.extra {
                 s.push_str(&format!(",\n  \"{}\": \"{}\"", k, v));
             }
+        }
+        for (key, action) in &self.key_actions {
+            s.push_str(&format!(",\n  \"key_action.{}\": \"{}\"", key, action));
+        }
+        for (target, command) in &self.app_launch_commands {
+            s.push_str(&format!(",\n  \"app_launch.{}\": \"{}\"", target, command));
         }
         s.push_str("\n}");
         s
@@ -229,6 +326,24 @@ impl CompositorConfig {
   "default_scale": 1.0,
   "cursor_theme": "Adwaita",
   "cursor_size": 24,
+
+  // Workspace policy
+  "workspace_count": 4,
+  "active_workspace": 0,
+  "layout_mode": "tiling",
+  "key_action.s-1": "workspace-switch:0",
+  "key_action.s-2": "workspace-switch:1",
+  "key_action.s-SPC": "layout-cycle",
+  "key_action.s-r": "config-reload",
+  // "key_action.s-RET": "app-launch:terminal",
+  // "app_launch.terminal": "foot",
+
+  // Native startup/session policy
+  "autostart_enabled": false,
+  "autostart_targets": "",
+  // "session_lock_command": "swaylock",
+  "session_idle_enabled": false,
+  // "session_idle_command": "swayidle -w",
 
   // VR
   "vr_enabled": false,
@@ -265,11 +380,7 @@ fn parse_flat_json(json: &str) -> Result<Vec<(String, String)>, String> {
         let trimmed = line.trim();
 
         // Skip blank lines, braces, and comment lines.
-        if trimmed.is_empty()
-            || trimmed == "{"
-            || trimmed == "}"
-            || trimmed.starts_with("//")
-        {
+        if trimmed.is_empty() || trimmed == "{" || trimmed == "}" || trimmed.starts_with("//") {
             continue;
         }
 
@@ -313,6 +424,34 @@ fn unquote(s: &str) -> String {
     }
 }
 
+fn parse_string_list(s: &str) -> Vec<String> {
+    let trimmed = s.trim();
+    let body = if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+    body.split(',')
+        .map(unquote)
+        .map(|item| item.trim().to_string())
+        .filter(|item| !item.is_empty())
+        .collect()
+}
+
+fn default_key_actions() -> HashMap<String, String> {
+    let mut actions = HashMap::new();
+    for workspace in 0..4 {
+        actions.insert(
+            format!("s-{}", workspace + 1),
+            format!("workspace-switch:{}", workspace),
+        );
+    }
+    actions.insert("s-SPC".to_string(), "layout-cycle".to_string());
+    actions.insert("s-r".to_string(), "config-reload".to_string());
+    actions.insert("s-q".to_string(), "compositor-exit".to_string());
+    actions
+}
+
 // ── Tests ────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -327,6 +466,15 @@ mod tests {
         assert!((cfg.default_scale - 1.0).abs() < f64::EPSILON);
         assert_eq!(cfg.cursor_theme, "Adwaita");
         assert_eq!(cfg.cursor_size, 24);
+        assert_eq!(cfg.workspace_count, 4);
+        assert_eq!(cfg.active_workspace, 0);
+        assert_eq!(cfg.layout_mode, "tiling");
+        assert_eq!(
+            cfg.key_actions.get("s-1").map(String::as_str),
+            Some("workspace-switch:0")
+        );
+        assert!(!cfg.autostart_enabled);
+        assert!(cfg.autostart_targets.is_empty());
         assert!(!cfg.vr_enabled);
         assert_eq!(cfg.vr_runtime, "monado");
         assert_eq!(cfg.follow_policy, "threshold-only");
@@ -349,6 +497,10 @@ mod tests {
         let json = cfg.to_json_string();
         assert!(json.contains("\"log_level\": \"info\""));
         assert!(json.contains("\"cursor_size\": 24"));
+        assert!(json.contains("\"workspace_count\": 4"));
+        assert!(json.contains("\"active_workspace\": 0"));
+        assert!(json.contains("\"layout_mode\": \"tiling\""));
+        assert!(json.contains("\"autostart_enabled\": false"));
         assert!(json.contains("\"vr_enabled\": false"));
         assert!(json.contains("\"gpu_auto_vr_boost\": true"));
 
@@ -356,6 +508,9 @@ mod tests {
         let parsed = CompositorConfig::parse_json(&json).unwrap();
         assert_eq!(parsed.log_level, "info");
         assert_eq!(parsed.cursor_size, 24);
+        assert_eq!(parsed.workspace_count, 4);
+        assert_eq!(parsed.active_workspace, 0);
+        assert_eq!(parsed.layout_mode, "tiling");
         assert!(!parsed.vr_enabled);
         assert!(parsed.gpu_auto_vr_boost);
     }
@@ -365,11 +520,37 @@ mod tests {
         let json = r#"{
             "vr_enabled": true,
             "cursor_size": 48,
+            "workspace_count": 6,
+            "active_workspace": 2,
+            "layout_mode": "monocle",
+            "key_action.s-RET": "app-launch:terminal",
+            "app_launch.terminal": "foot",
+            "autostart_enabled": true,
+            "autostart_targets": "terminal,browser",
+            "session_lock_command": "swaylock",
+            "session_idle_enabled": true,
+            "session_idle_command": "swayidle -w",
             "gpu_power_profile": "high"
         }"#;
         let cfg = CompositorConfig::parse_json(json).unwrap();
         assert!(cfg.vr_enabled);
         assert_eq!(cfg.cursor_size, 48);
+        assert_eq!(cfg.workspace_count, 6);
+        assert_eq!(cfg.active_workspace, 2);
+        assert_eq!(cfg.layout_mode, "monocle");
+        assert_eq!(
+            cfg.key_actions.get("s-RET").map(String::as_str),
+            Some("app-launch:terminal")
+        );
+        assert_eq!(
+            cfg.app_launch_commands.get("terminal").map(String::as_str),
+            Some("foot")
+        );
+        assert!(cfg.autostart_enabled);
+        assert_eq!(cfg.autostart_targets, vec!["terminal", "browser"]);
+        assert_eq!(cfg.session_lock_command.as_deref(), Some("swaylock"));
+        assert!(cfg.session_idle_enabled);
+        assert_eq!(cfg.session_idle_command.as_deref(), Some("swayidle -w"));
         assert_eq!(cfg.gpu_power_profile, "high");
         // Untouched fields keep defaults.
         assert_eq!(cfg.log_level, "info");
@@ -409,9 +590,43 @@ mod tests {
     }
 
     #[test]
+    fn test_ipc_socket_pathbuf() {
+        let json = r#"{
+            "ipc_socket_path": "/tmp/xoxdwm-ipc.sock"
+        }"#;
+        let cfg = CompositorConfig::parse_json(json).unwrap();
+        assert_eq!(
+            cfg.ipc_socket_pathbuf().unwrap(),
+            PathBuf::from("/tmp/xoxdwm-ipc.sock")
+        );
+    }
+
+    #[test]
+    fn test_workspace_normalization() {
+        let json = r#"{
+            "workspace_count": 0,
+            "active_workspace": 9
+        }"#;
+        let cfg = CompositorConfig::parse_json(json).unwrap();
+        assert_eq!(cfg.normalized_workspace_count(), 1);
+        assert_eq!(cfg.normalized_active_workspace(), 0);
+
+        let json = r#"{
+            "workspace_count": 3,
+            "active_workspace": 9
+        }"#;
+        let cfg = CompositorConfig::parse_json(json).unwrap();
+        assert_eq!(cfg.normalized_workspace_count(), 3);
+        assert_eq!(cfg.normalized_active_workspace(), 2);
+    }
+
+    #[test]
     fn test_generate_default_config() {
         let text = CompositorConfig::generate_default_config();
         assert!(text.contains("\"log_level\": \"info\""));
+        assert!(text.contains("\"workspace_count\": 4"));
+        assert!(text.contains("\"key_action.s-1\""));
+        assert!(text.contains("\"autostart_enabled\": false"));
         assert!(text.contains("\"gpu_auto_vr_boost\": true"));
         assert!(text.contains("// EXWM-VR compositor configuration"));
     }

--- a/compositor/src/handlers/output_management.rs
+++ b/compositor/src/handlers/output_management.rs
@@ -131,6 +131,20 @@ impl OutputManagementState {
         Self::default()
     }
 
+    /// Synchronize a compositor-detected output into the IPC-visible state.
+    pub fn upsert_detected_output(&mut self, config: OutputConfig) {
+        if let Some(existing) = self.configs.iter_mut().find(|c| c.name == config.name) {
+            *existing = config;
+        } else {
+            self.configs.push(config);
+        }
+    }
+
+    /// Remove an output that is no longer mapped by the backend.
+    pub fn remove_detected_output(&mut self, name: &str) {
+        self.configs.retain(|c| c.name != name);
+    }
+
     /// Apply a configuration change.  Returns `Ok(serial)` on success.
     /// In a full implementation this would program the DRM/KMS backend.
     pub fn apply_config(&mut self, config: OutputConfig) -> Result<u32, String> {
@@ -239,6 +253,28 @@ mod tests {
         let s1 = state.apply_config(OutputConfig::new("a".into())).unwrap();
         let s2 = state.apply_config(OutputConfig::new("b".into())).unwrap();
         assert_eq!(s2, s1 + 1);
+    }
+
+    #[test]
+    fn detected_output_sync_populates_ipc_state() {
+        let mut state = OutputManagementState::new();
+        let mut cfg = OutputConfig::new("HDMI-A-1".into());
+        cfg.width = 1920;
+        cfg.height = 1080;
+        state.upsert_detected_output(cfg);
+
+        assert_eq!(state.configs.len(), 1);
+        assert_eq!(state.configs[0].name, "HDMI-A-1");
+        assert_eq!(state.configs[0].width, 1920);
+    }
+
+    #[test]
+    fn detected_output_sync_removes_unmapped_outputs() {
+        let mut state = OutputManagementState::new();
+        state.upsert_detected_output(OutputConfig::new("DP-1".into()));
+        state.remove_detected_output("DP-1");
+
+        assert!(state.configs.is_empty());
     }
 
     #[test]

--- a/compositor/src/input.rs
+++ b/compositor/src/input.rs
@@ -72,11 +72,20 @@ fn handle_keyboard<B: InputBackend>(state: &mut EwwmState, event: B::KeyboardKey
     let keyboard = state.seat.get_keyboard().unwrap();
 
     // Check for grabbed keys
-    let _grab_result =
-        keyboard.input::<bool, _>(state, keycode, key_state, serial, time, |state, mods, handle| {
+    let _grab_result = keyboard.input::<bool, _>(
+        state,
+        keycode,
+        key_state,
+        serial,
+        time,
+        |state, mods, handle| {
             if key_state == KeyState::Pressed {
                 let keysym = handle.modified_sym();
                 if let Some(key_desc) = format_key_description(keysym, mods) {
+                    if state.handle_native_key_action(&key_desc) {
+                        debug!(key = %key_desc, "native key action handled");
+                        return FilterResult::Intercept(true);
+                    }
                     if state.grabbed_keys.contains(&key_desc) {
                         debug!(key = %key_desc, "grabbed key intercepted");
                         // Emit key-pressed event to IPC clients
@@ -103,7 +112,8 @@ fn handle_keyboard<B: InputBackend>(state: &mut EwwmState, event: B::KeyboardKey
                 }
             }
             FilterResult::Forward
-        });
+        },
+    );
 }
 
 fn handle_pointer_motion_absolute<B: InputBackend>(

--- a/compositor/src/ipc/dispatch.rs
+++ b/compositor/src/ipc/dispatch.rs
@@ -1,7 +1,7 @@
 //! IPC message dispatch — parse s-expressions and route to handlers.
 
-use crate::state::EwwmState;
 use super::server::IpcServer;
+use crate::state::EwwmState;
 use lexpr::Value;
 use tracing::{debug, warn};
 
@@ -45,9 +45,22 @@ pub fn handle_message(state: &mut EwwmState, client_id: u64, raw: &str) -> Optio
         Some("workspace-move-surface") => handle_workspace_move_surface(state, msg_id, &value),
         Some("layout-set") => handle_layout_set(state, msg_id, &value),
         Some("layout-cycle") => handle_layout_cycle(state, msg_id),
+        Some("app-launch") | Some("launch-app") => handle_app_launch(state, msg_id, &value),
+        Some("app-launch-list") => handle_app_launch_list(state, msg_id),
+        Some("config-reload") | Some("reload-config") => handle_config_reload(state, msg_id),
+        Some("autostart-list") => handle_autostart_list(state, msg_id),
+        Some("autostart-run") => handle_autostart_run(state, msg_id, &value),
+        Some("session-status") => handle_session_status(state, msg_id),
+        Some("session-lock") => handle_session_lock(state, msg_id),
+        Some("session-logout") => handle_session_logout(state, msg_id),
+        Some("session-idle-status") => handle_session_idle_status(state, msg_id),
+        Some("session-idle-start") => handle_session_idle_start(state, msg_id),
+        Some("session-idle-stop") => handle_session_idle_stop(state, msg_id),
+        Some("compositor-exit") => handle_compositor_exit(state, msg_id),
         Some("key-grab") => handle_key_grab(state, msg_id, &value),
         Some("key-ungrab") => handle_key_ungrab(state, msg_id, &value),
         Some("vr-status") => handle_vr_status(state, msg_id),
+        Some("vr-diagnostics") => handle_vr_diagnostics(state, msg_id),
         Some("vr-set-reference-space") => handle_vr_set_reference_space(state, msg_id, &value),
         Some("vr-restart") => handle_vr_restart(state, msg_id),
         Some("vr-get-frame-timing") => handle_vr_get_frame_timing(state, msg_id),
@@ -61,7 +74,9 @@ pub fn handle_message(state: &mut EwwmState, client_id: u64, raw: &str) -> Optio
         Some("vr-display-info") => handle_vr_display_info(state, msg_id),
         Some("vr-display-set-mode") => handle_vr_display_set_mode(state, msg_id, &value),
         Some("vr-display-select-hmd") => handle_vr_display_select_hmd(state, msg_id, &value),
-        Some("vr-display-set-refresh-rate") => handle_vr_display_set_refresh_rate(state, msg_id, &value),
+        Some("vr-display-set-refresh-rate") => {
+            handle_vr_display_set_refresh_rate(state, msg_id, &value)
+        }
         Some("vr-display-auto-detect") => handle_vr_display_auto_detect(state, msg_id),
         Some("vr-display-list-connectors") => handle_vr_display_list_connectors(state, msg_id),
         Some("vr-pointer-state") => handle_vr_pointer_state(state, msg_id),
@@ -156,8 +171,12 @@ pub fn handle_message(state: &mut EwwmState, client_id: u64, raw: &str) -> Optio
         // BCI attention
         Some("bci-attention-status") => handle_bci_attention_status(state, msg_id),
         Some("bci-attention-config") => handle_bci_attention_config(state, msg_id, &value),
-        Some("bci-attention-calibrate-start") => handle_bci_attention_calibrate_start(state, msg_id),
-        Some("bci-attention-calibrate-finish") => handle_bci_attention_calibrate_finish(state, msg_id),
+        Some("bci-attention-calibrate-start") => {
+            handle_bci_attention_calibrate_start(state, msg_id)
+        }
+        Some("bci-attention-calibrate-finish") => {
+            handle_bci_attention_calibrate_finish(state, msg_id)
+        }
         // BCI SSVEP
         Some("bci-ssvep-status") => handle_bci_ssvep_status(state, msg_id),
         Some("bci-ssvep-config") => handle_bci_ssvep_config(state, msg_id, &value),
@@ -263,11 +282,12 @@ fn handle_hello(
             if peer_uid != our_uid {
                 warn!(
                     client_id,
-                    peer_uid,
-                    our_uid,
-                    "rejecting client: UID mismatch"
+                    peer_uid, our_uid, "rejecting client: UID mismatch"
                 );
-                return Some(error_response(msg_id, "authentication failed: UID mismatch"));
+                return Some(error_response(
+                    msg_id,
+                    "authentication failed: UID mismatch",
+                ));
             }
         }
     }
@@ -289,7 +309,11 @@ fn handle_hello(
     let pid_field = peer_pid
         .map(|p| format!(" :peer-pid {}", p))
         .unwrap_or_default();
-    let xwayland_flag = if cfg!(feature = "xwayland") { "t" } else { "nil" };
+    let xwayland_flag = if cfg!(feature = "xwayland") {
+        "t"
+    } else {
+        "nil"
+    };
     Some(format!(
         "(:type :hello :id {} :version 1 :server \"ewwm-compositor\" :features (:xwayland {} :vr {}){})",
         msg_id, xwayland_flag, vr_flag, pid_field
@@ -421,18 +445,7 @@ fn handle_surface_focus(state: &mut EwwmState, msg_id: i64, value: &Value) -> Op
         ));
     }
 
-    // Find the Window by surface_id and raise it
-    let window = state.find_window(surface_id).cloned();
-
-    if let Some(w) = window {
-        state.space.raise_element(&w, true);
-        let keyboard = state.seat.get_keyboard().unwrap();
-        let serial = smithay::utils::SERIAL_COUNTER.next_serial();
-        let wl_surface = w.toplevel().map(|t| t.wl_surface().clone());
-        if let Some(surface) = wl_surface {
-            keyboard.set_focus(state, Some(surface), serial);
-        }
-    }
+    state.focus_surface(surface_id);
 
     Some(ok_response(msg_id))
 }
@@ -475,10 +488,13 @@ fn handle_surface_move(state: &mut EwwmState, msg_id: i64, value: &Value) -> Opt
         ));
     }
 
-    // Find window by surface_id and remap at new location
-    if let Some(w) = state.find_window(surface_id).cloned() {
-        state.space.map_element(w, (x, y), false);
-    }
+    let current = state
+        .surfaces
+        .get(&surface_id)
+        .map(|data| data.geometry)
+        .unwrap_or_else(|| state.initial_window_geometry());
+    let geometry = smithay::utils::Rectangle::new((x, y).into(), current.size);
+    state.set_surface_geometry(surface_id, geometry);
 
     Some(ok_response(msg_id))
 }
@@ -498,24 +514,18 @@ fn handle_surface_resize(state: &mut EwwmState, msg_id: i64, value: &Value) -> O
         ));
     }
 
-    // Resize via pending state using proper surface_id lookup
-    if let Some(win) = state.find_window(surface_id) {
-        if let Some(toplevel) = win.toplevel() {
-            toplevel.with_pending_state(|s| {
-                s.size = Some(smithay::utils::Size::from((w, h)));
-            });
-            toplevel.send_pending_configure();
-        }
-    }
+    let current = state
+        .surfaces
+        .get(&surface_id)
+        .map(|data| data.geometry)
+        .unwrap_or_else(|| state.initial_window_geometry());
+    let geometry = smithay::utils::Rectangle::new(current.loc, (w, h).into());
+    state.set_surface_geometry(surface_id, geometry);
 
     Some(ok_response(msg_id))
 }
 
-fn handle_surface_fullscreen(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_surface_fullscreen(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::State as ToplevelState;
 
     let surface_id = match get_int(value, "surface-id") {
@@ -525,7 +535,10 @@ fn handle_surface_fullscreen(
     let enable = get_bool(value, "enable").unwrap_or(true);
 
     if !state.surfaces.contains_key(&surface_id) {
-        return Some(error_response(msg_id, &format!("unknown surface: {surface_id}")));
+        return Some(error_response(
+            msg_id,
+            &format!("unknown surface: {surface_id}"),
+        ));
     }
 
     if let Some(win) = state.find_window(surface_id) {
@@ -555,11 +568,17 @@ fn handle_surface_float(state: &mut EwwmState, msg_id: i64, value: &Value) -> Op
 
     let data = match state.surfaces.get_mut(&surface_id) {
         Some(d) => d,
-        None => return Some(error_response(msg_id, &format!("unknown surface: {surface_id}"))),
+        None => {
+            return Some(error_response(
+                msg_id,
+                &format!("unknown surface: {surface_id}"),
+            ))
+        }
     };
 
     data.floating = enable;
     debug!(surface_id, floating = enable, "float toggle");
+    state.reflow_native_layout();
 
     let event = format_event(
         "surface-float-changed",
@@ -574,15 +593,34 @@ fn handle_surface_float(state: &mut EwwmState, msg_id: i64, value: &Value) -> Op
 }
 
 fn handle_workspace_switch(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
-    let workspace = get_int(value, "workspace").unwrap_or(0);
+    let workspace = match get_int(value, "workspace") {
+        Some(w) if w >= 0 => w as usize,
+        Some(w) => return Some(error_response(msg_id, &format!("invalid workspace: {w}"))),
+        None => 0,
+    };
+    if workspace >= state.workspace_count {
+        return Some(error_response(
+            msg_id,
+            &format!(
+                "workspace {} out of range (count {})",
+                workspace, state.workspace_count
+            ),
+        ));
+    }
     debug!(workspace, "workspace switch");
-    state.active_workspace = workspace as usize;
+    state.active_workspace = workspace;
+    state.reflow_native_layout();
+    let event = format_event(
+        "workspace-changed",
+        &[("workspace", &workspace.to_string())],
+    );
+    IpcServer::broadcast_event(state, &event);
     Some(ok_response(msg_id))
 }
 
 fn handle_workspace_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     let mut workspaces = String::from("(");
-    for i in 0..4 {
+    for i in 0..state.workspace_count {
         let active = if i == state.active_workspace {
             "t"
         } else {
@@ -623,18 +661,38 @@ fn handle_workspace_move_surface(
         None => return Some(error_response(msg_id, "missing :surface-id")),
     };
     let workspace = match get_int(value, "workspace") {
-        Some(w) => w as usize,
+        Some(w) if w >= 0 => w as usize,
+        Some(w) => return Some(error_response(msg_id, &format!("invalid workspace: {w}"))),
         None => return Some(error_response(msg_id, "missing :workspace")),
     };
+    if workspace >= state.workspace_count {
+        return Some(error_response(
+            msg_id,
+            &format!(
+                "workspace {} out of range (count {})",
+                workspace, state.workspace_count
+            ),
+        ));
+    }
 
     let data = match state.surfaces.get_mut(&surface_id) {
         Some(d) => d,
-        None => return Some(error_response(msg_id, &format!("unknown surface: {surface_id}"))),
+        None => {
+            return Some(error_response(
+                msg_id,
+                &format!("unknown surface: {surface_id}"),
+            ))
+        }
     };
 
     let old_workspace = data.workspace;
     data.workspace = workspace;
-    debug!(surface_id, from = old_workspace, to = workspace, "workspace move");
+    debug!(
+        surface_id,
+        from = old_workspace,
+        to = workspace,
+        "workspace move"
+    );
 
     let event = format_event(
         "surface-workspace-changed",
@@ -645,22 +703,224 @@ fn handle_workspace_move_surface(
         ],
     );
     IpcServer::broadcast_event(state, &event);
+    state.reflow_native_layout();
 
     Some(ok_response(msg_id))
 }
 
-fn handle_layout_set(_state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
-    // Layout is driven by Emacs (the WM brain). The compositor just
-    // acknowledges the request. Emacs calls surface-move / surface-resize
-    // to position each window.
+fn handle_layout_set(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let layout = get_string(value, "layout").unwrap_or_default();
-    debug!(layout, "layout set (Emacs-driven)");
+    state.set_native_layout(&layout);
+    debug!(layout, "native layout set");
+    let event = format_event("layout-changed", &[("layout", &format!("\"{}\"", layout))]);
+    IpcServer::broadcast_event(state, &event);
+    Some(format!(
+        "(:type :response :id {} :status :ok :layout \"{}\")",
+        msg_id,
+        escape_string(&state.current_layout)
+    ))
+}
+
+fn handle_layout_cycle(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    state.cycle_native_layout();
+    debug!(layout = state.current_layout, "native layout cycle");
+    let event = format_event(
+        "layout-changed",
+        &[("layout", &format!("\"{}\"", state.current_layout))],
+    );
+    IpcServer::broadcast_event(state, &event);
+    Some(format!(
+        "(:type :response :id {} :status :ok :layout \"{}\")",
+        msg_id,
+        escape_string(&state.current_layout)
+    ))
+}
+
+fn handle_app_launch(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
+    let target = get_string(value, "target")
+        .or_else(|| get_string(value, "name"))
+        .or_else(|| get_string(value, "app"));
+    let target = match target {
+        Some(target) => target,
+        None => return Some(error_response(msg_id, "missing :target")),
+    };
+    match state.launch_configured_app(&target) {
+        Ok(pid) => {
+            let event = format_event(
+                "app-launched",
+                &[
+                    ("target", &format!("\"{}\"", escape_string(&target))),
+                    ("pid", &pid.to_string()),
+                ],
+            );
+            IpcServer::broadcast_event(state, &event);
+            Some(format!(
+                "(:type :response :id {} :status :ok :target \"{}\" :pid {})",
+                msg_id,
+                escape_string(&target),
+                pid
+            ))
+        }
+        Err(err) => Some(error_response(msg_id, &err)),
+    }
+}
+
+fn handle_app_launch_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    let mut targets: Vec<String> = state
+        .config
+        .app_launch_commands
+        .keys()
+        .map(|target| format!("\"{}\"", escape_string(target)))
+        .collect();
+    targets.sort();
+    Some(format!(
+        "(:type :response :id {} :status :ok :targets ({}))",
+        msg_id,
+        targets.join(" ")
+    ))
+}
+
+fn handle_config_reload(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    match state.reload_native_config() {
+        Ok(()) => {
+            let event = format_event(
+                "config-reloaded",
+                &[
+                    ("workspace-count", &state.workspace_count.to_string()),
+                    ("active-workspace", &state.active_workspace.to_string()),
+                    (
+                        "layout",
+                        &format!("\"{}\"", escape_string(&state.current_layout)),
+                    ),
+                ],
+            );
+            IpcServer::broadcast_event(state, &event);
+            Some(format!(
+                "(:type :response :id {} :status :ok :workspace-count {} :active-workspace {} :layout \"{}\")",
+                msg_id,
+                state.workspace_count,
+                state.active_workspace,
+                escape_string(&state.current_layout)
+            ))
+        }
+        Err(err) => Some(error_response(msg_id, &err)),
+    }
+}
+
+fn handle_autostart_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    let targets: Vec<String> = state
+        .config
+        .autostart_targets
+        .iter()
+        .map(|target| {
+            format!(
+                "(:target \"{}\" :configured {} :launched {})",
+                escape_string(target),
+                if state.config.app_launch_commands.contains_key(target) {
+                    "t"
+                } else {
+                    "nil"
+                },
+                if state.autostart_launched.contains(target) {
+                    "t"
+                } else {
+                    "nil"
+                }
+            )
+        })
+        .collect();
+    Some(format!(
+        "(:type :response :id {} :status :ok :enabled {} :targets ({}))",
+        msg_id,
+        if state.config.autostart_enabled {
+            "t"
+        } else {
+            "nil"
+        },
+        targets.join(" ")
+    ))
+}
+
+fn handle_autostart_run(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
+    let force = get_bool(value, "force").unwrap_or(false);
+    let (launched, skipped, errors) = state.run_autostart(force);
+    for target in &launched {
+        let event = format_event(
+            "autostart-ran",
+            &[("target", &format!("\"{}\"", escape_string(target)))],
+        );
+        IpcServer::broadcast_event(state, &event);
+    }
+    Some(format!(
+        "(:type :response :id {} :status :ok :launched ({}) :skipped ({}) :errors ({}))",
+        msg_id,
+        quoted_list(&launched),
+        quoted_list(&skipped),
+        quoted_list(&errors)
+    ))
+}
+
+fn handle_session_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    let lock_running = EwwmState::child_running(&mut state.session_lock_child);
+    let idle_running = EwwmState::child_running(&mut state.session_idle_child);
+    Some(format!(
+        "(:type :response :id {} :status :ok :locked {} :lock-running {} :lock-command-configured {} :idle-running {} :idle-enabled {})",
+        msg_id,
+        if state.session_locked { "t" } else { "nil" },
+        if lock_running { "t" } else { "nil" },
+        if state.config.session_lock_command.is_some() { "t" } else { "nil" },
+        if idle_running { "t" } else { "nil" },
+        if state.config.session_idle_enabled { "t" } else { "nil" },
+    ))
+}
+
+fn handle_session_lock(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    match state.start_session_lock() {
+        Ok(()) => Some(ok_response(msg_id)),
+        Err(err) => Some(error_response(msg_id, &err)),
+    }
+}
+
+fn handle_session_logout(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    state.running = false;
     Some(ok_response(msg_id))
 }
 
-fn handle_layout_cycle(_state: &mut EwwmState, msg_id: i64) -> Option<String> {
-    // Layout cycling is handled by Emacs. ACK the request.
-    debug!("layout cycle (Emacs-driven)");
+fn handle_session_idle_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    let running = EwwmState::child_running(&mut state.session_idle_child);
+    Some(format!(
+        "(:type :response :id {} :status :ok :running {} :enabled {} :command-configured {})",
+        msg_id,
+        if running { "t" } else { "nil" },
+        if state.config.session_idle_enabled {
+            "t"
+        } else {
+            "nil"
+        },
+        if state.config.session_idle_command.is_some() {
+            "t"
+        } else {
+            "nil"
+        },
+    ))
+}
+
+fn handle_session_idle_start(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    match state.start_session_idle() {
+        Ok(()) => Some(ok_response(msg_id)),
+        Err(err) => Some(error_response(msg_id, &err)),
+    }
+}
+
+fn handle_session_idle_stop(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    match state.stop_session_idle() {
+        Ok(()) => Some(ok_response(msg_id)),
+        Err(err) => Some(error_response(msg_id, &err)),
+    }
+}
+
+fn handle_compositor_exit(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    state.running = false;
     Some(ok_response(msg_id))
 }
 
@@ -687,11 +947,23 @@ fn handle_key_ungrab(state: &mut EwwmState, msg_id: i64, value: &Value) -> Optio
 fn handle_vr_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     let session = state.vr_state.session_state_str();
     let hmd = state.vr_state.hmd_name();
-    let headless = if state.vr_state.is_headless() { "t" } else { "nil" };
+    let headless = if state.vr_state.is_headless() {
+        "t"
+    } else {
+        "nil"
+    };
     let frame_stats = state.vr_state.frame_stats_sexp();
     Some(format!(
         "(:type :response :id {} :status :ok :session :{} :hmd \"{}\" :headless {} :frame-stats {})",
         msg_id, session, escape_string(hmd), headless, frame_stats
+    ))
+}
+
+fn handle_vr_diagnostics(state: &mut EwwmState, msg_id: i64) -> Option<String> {
+    let diagnostics = state.vr_state.diagnostics_sexp();
+    Some(format!(
+        "(:type :response :id {} :status :ok :vr-diagnostics {})",
+        msg_id, diagnostics
     ))
 }
 
@@ -703,18 +975,27 @@ fn handle_vr_set_reference_space(
     let space_type = get_keyword(value, "space-type");
     match space_type.as_deref() {
         Some("local") => {
-            state.vr_state.set_reference_space(crate::vr::ReferenceSpaceType::Local);
+            state
+                .vr_state
+                .set_reference_space(crate::vr::ReferenceSpaceType::Local);
             Some(ok_response(msg_id))
         }
         Some("stage") => {
-            state.vr_state.set_reference_space(crate::vr::ReferenceSpaceType::Stage);
+            state
+                .vr_state
+                .set_reference_space(crate::vr::ReferenceSpaceType::Stage);
             Some(ok_response(msg_id))
         }
         Some("view") => {
-            state.vr_state.set_reference_space(crate::vr::ReferenceSpaceType::View);
+            state
+                .vr_state
+                .set_reference_space(crate::vr::ReferenceSpaceType::View);
             Some(ok_response(msg_id))
         }
-        _ => Some(error_response(msg_id, "invalid :space-type (use local, stage, or view)")),
+        _ => Some(error_response(
+            msg_id,
+            "invalid :space-type (use local, stage, or view)",
+        )),
     }
 }
 
@@ -740,11 +1021,7 @@ fn handle_vr_scene_status(state: &mut EwwmState, msg_id: i64) -> Option<String> 
     ))
 }
 
-fn handle_vr_scene_set_layout(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_scene_set_layout(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::scene::VrLayoutMode;
 
     let layout = get_keyword(value, "layout");
@@ -759,21 +1036,27 @@ fn handle_vr_scene_set_layout(
         Some("grid") => VrLayoutMode::Grid {
             columns: get_int(value, "columns").unwrap_or(2) as u32,
         },
-        _ => return Some(error_response(msg_id, "invalid :layout (use arc, grid, stack, freeform)")),
+        _ => {
+            return Some(error_response(
+                msg_id,
+                "invalid :layout (use arc, grid, stack, freeform)",
+            ))
+        }
     };
 
     state.vr_state.scene.set_layout(mode);
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_scene_set_ppu(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_scene_set_ppu(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let ppu = match get_int(value, "ppu") {
         Some(p) if p > 0 => p as f32,
-        _ => return Some(error_response(msg_id, "invalid :ppu (must be positive integer)")),
+        _ => {
+            return Some(error_response(
+                msg_id,
+                "invalid :ppu (must be positive integer)",
+            ))
+        }
     };
 
     let surface_id = get_int(value, "surface-id");
@@ -798,7 +1081,12 @@ fn handle_vr_scene_set_background(
         Some("gradient") => VrBackground::Gradient,
         Some("grid") => VrBackground::Grid,
         Some("passthrough") => VrBackground::Passthrough,
-        _ => return Some(error_response(msg_id, "invalid :background (use dark, gradient, grid, passthrough)")),
+        _ => {
+            return Some(error_response(
+                msg_id,
+                "invalid :background (use dark, gradient, grid, passthrough)",
+            ))
+        }
     };
 
     state.vr_state.scene.background = background;
@@ -821,29 +1109,26 @@ fn handle_vr_scene_set_projection(
     let projection = match proj.as_deref() {
         Some("flat") => ProjectionType::Flat,
         Some("cylinder") => ProjectionType::Cylinder,
-        _ => return Some(error_response(msg_id, "invalid :projection (use flat, cylinder)")),
+        _ => {
+            return Some(error_response(
+                msg_id,
+                "invalid :projection (use flat, cylinder)",
+            ))
+        }
     };
 
     state.vr_state.scene.set_projection(surface_id, projection);
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_scene_focus(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_scene_focus(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let surface_id = get_int(value, "surface-id").map(|id| id as u64);
     state.vr_state.scene.set_focus(surface_id);
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_scene_move(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
-    use crate::vr::scene::{Transform3D, Vec3, Quat};
+fn handle_vr_scene_move(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
+    use crate::vr::scene::{Quat, Transform3D, Vec3};
 
     let surface_id = match get_int(value, "surface-id") {
         Some(id) => id as u64,
@@ -874,17 +1159,18 @@ fn handle_vr_display_info(state: &mut EwwmState, msg_id: i64) -> Option<String> 
     ))
 }
 
-fn handle_vr_display_set_mode(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_display_set_mode(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::drm_lease::VrDisplayMode;
 
     let mode_str = get_keyword(value, "mode");
     let mode = match mode_str.as_deref().and_then(VrDisplayMode::from_str) {
         Some(m) => m,
-        None => return Some(error_response(msg_id, "invalid :mode (use headset, preview, headless, off)")),
+        None => {
+            return Some(error_response(
+                msg_id,
+                "invalid :mode (use headset, preview, headless, off)",
+            ))
+        }
     };
 
     state.vr_state.hmd_manager.set_display_mode(mode);
@@ -904,7 +1190,10 @@ fn handle_vr_display_select_hmd(
     if state.vr_state.hmd_manager.select_hmd(connector_id) {
         Some(ok_response(msg_id))
     } else {
-        Some(error_response(msg_id, &format!("connector {} not found or not an HMD", connector_id)))
+        Some(error_response(
+            msg_id,
+            &format!("connector {} not found or not an HMD", connector_id),
+        ))
     }
 }
 
@@ -915,7 +1204,12 @@ fn handle_vr_display_set_refresh_rate(
 ) -> Option<String> {
     let target = match get_int(value, "rate") {
         Some(r) if r > 0 => r as u32,
-        _ => return Some(error_response(msg_id, "invalid :rate (must be positive integer)")),
+        _ => {
+            return Some(error_response(
+                msg_id,
+                "invalid :rate (must be positive integer)",
+            ))
+        }
     };
 
     let actual = state.vr_state.hmd_manager.set_target_refresh_rate(target);
@@ -963,19 +1257,30 @@ fn handle_vr_click(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<
     let button_str = get_keyword(value, "button").unwrap_or_else(|| "left".to_string());
     let click = match ClickType::from_str(&button_str) {
         Some(c) => c,
-        None => return Some(error_response(msg_id, "invalid :button (use left, right, middle, double)")),
+        None => {
+            return Some(error_response(
+                msg_id,
+                "invalid :button (use left, right, middle, double)",
+            ))
+        }
     };
 
     let target = state.vr_state.interaction.current_hit.map(|h| h.surface_id);
     let ptr = &state.vr_state.interaction.active_pointer;
-    let (px, py) = ptr.as_ref().map(|p| (p.pixel_x, p.pixel_y)).unwrap_or((0, 0));
+    let (px, py) = ptr
+        .as_ref()
+        .map(|p| (p.pixel_x, p.pixel_y))
+        .unwrap_or((0, 0));
 
     Some(format!(
         "(:type :response :id {} :status :ok :button :{} :surface-id {} :x {} :y {})",
         msg_id,
         click.as_str(),
-        target.map(|id| id.to_string()).unwrap_or_else(|| "nil".to_string()),
-        px, py
+        target
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "nil".to_string()),
+        px,
+        py
     ))
 }
 
@@ -999,12 +1304,8 @@ fn handle_vr_grab_release(state: &mut EwwmState, msg_id: i64) -> Option<String> 
     }
 }
 
-fn handle_vr_adjust_depth(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
-    use crate::vr::vr_interaction::{adjust_depth, DEPTH_MIN, DEPTH_MAX};
+fn handle_vr_adjust_depth(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
+    use crate::vr::vr_interaction::{adjust_depth, DEPTH_MAX, DEPTH_MIN};
 
     let surface_id = match get_int(value, "surface-id") {
         Some(id) => id as u64,
@@ -1021,15 +1322,14 @@ fn handle_vr_adjust_depth(
             msg_id, surface_id, -new_z
         ))
     } else {
-        Some(error_response(msg_id, &format!("unknown surface: {}", surface_id)))
+        Some(error_response(
+            msg_id,
+            &format!("unknown surface: {}", surface_id),
+        ))
     }
 }
 
-fn handle_vr_set_follow(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_set_follow(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::vr_interaction::FollowMode;
 
     let surface_id = match get_int(value, "surface-id") {
@@ -1040,18 +1340,19 @@ fn handle_vr_set_follow(
     let mode_str = get_keyword(value, "mode");
     let mode = match mode_str.as_deref().and_then(FollowMode::from_str) {
         Some(m) => m,
-        None => return Some(error_response(msg_id, "invalid :mode (use none, lazy, sticky, locked)")),
+        None => {
+            return Some(error_response(
+                msg_id,
+                "invalid :mode (use none, lazy, sticky, locked)",
+            ))
+        }
     };
 
     state.vr_state.interaction.set_follow_mode(surface_id, mode);
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_set_gaze_offset(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_set_gaze_offset(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::scene::Vec3;
 
     let x = get_int(value, "x").unwrap_or(15) as f32 / 100.0;
@@ -1064,24 +1365,34 @@ fn handle_vr_set_gaze_offset(
 
 fn handle_vr_calibrate_confirm(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     let head_pose = state.vr_state.interaction.head_pose;
-    let done = state.vr_state.interaction.calibration.record_point(
-        crate::vr::vr_interaction::HeadPose {
-            position: head_pose.position,
-            rotation: head_pose.rotation,
-        },
-    );
+    let done =
+        state
+            .vr_state
+            .interaction
+            .calibration
+            .record_point(crate::vr::vr_interaction::HeadPose {
+                position: head_pose.position,
+                rotation: head_pose.rotation,
+            });
 
     if done {
         // Compute new offset
         if let Some(offset) = state.vr_state.interaction.calibration.compute_offset() {
-            let rms = state.vr_state.interaction.calibration.rms_error_deg(&offset);
+            let rms = state
+                .vr_state
+                .interaction
+                .calibration
+                .rms_error_deg(&offset);
             state.vr_state.interaction.gaze_config.offset = offset;
             Some(format!(
                 "(:type :response :id {} :status :ok :calibration :complete :rms-error {:.1} :offset (:x {:.3} :y {:.3} :z {:.3}))",
                 msg_id, rms, offset.x, offset.y, offset.z
             ))
         } else {
-            Some(error_response(msg_id, "calibration failed: insufficient data"))
+            Some(error_response(
+                msg_id,
+                "calibration failed: insufficient data",
+            ))
         }
     } else {
         let next = state.vr_state.interaction.calibration.current_target;
@@ -1102,11 +1413,7 @@ fn handle_gaze_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     ))
 }
 
-fn handle_gaze_set_source(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_set_source(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let source_str = get_keyword(value, "source").unwrap_or_default();
     use crate::vr::eye_tracking::GazeSource;
     let source = if source_str == "auto" {
@@ -1114,7 +1421,12 @@ fn handle_gaze_set_source(
     } else {
         match GazeSource::from_str(&source_str) {
             Some(s) => Some(s),
-            None => return Some(error_response(msg_id, &format!("unknown gaze source: {source_str}"))),
+            None => {
+                return Some(error_response(
+                    msg_id,
+                    &format!("unknown gaze source: {source_str}"),
+                ))
+            }
         }
     };
     state.vr_state.eye_tracking.set_source(source);
@@ -1201,25 +1513,20 @@ fn handle_gaze_set_visualization(
             state.vr_state.eye_tracking.set_visualization(vis);
             Some(ok_response(msg_id))
         }
-        None => Some(error_response(msg_id, &format!("unknown visualization: {vis_str}"))),
+        None => Some(error_response(
+            msg_id,
+            &format!("unknown visualization: {vis_str}"),
+        )),
     }
 }
 
-fn handle_gaze_set_smoothing(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_set_smoothing(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let alpha = get_int(value, "alpha").unwrap_or(30) as f32 / 100.0;
     state.vr_state.eye_tracking.set_smoothing(alpha);
     Some(ok_response(msg_id))
 }
 
-fn handle_gaze_simulate(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_simulate(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let mode_str = get_keyword(value, "mode").unwrap_or_default();
     use crate::vr::eye_tracking::SimulatedGazeMode;
     if mode_str == "off" || mode_str == "nil" {
@@ -1231,7 +1538,10 @@ fn handle_gaze_simulate(
             state.vr_state.eye_tracking.set_simulate(Some(mode));
             Some(ok_response(msg_id))
         }
-        None => Some(error_response(msg_id, &format!("unknown simulate mode: {mode_str}"))),
+        None => Some(error_response(
+            msg_id,
+            &format!("unknown simulate mode: {mode_str}"),
+        )),
     }
 }
 
@@ -1370,16 +1680,16 @@ fn handle_wink_calibrate_start(
     ))
 }
 
-fn handle_wink_set_confidence(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_wink_set_confidence(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let threshold = get_int(value, "threshold").unwrap_or(70) as f32 / 100.0;
     if !(0.0..=1.0).contains(&threshold) {
         return Some(error_response(msg_id, "invalid :threshold (0-100)"));
     }
-    state.vr_state.blink_wink.blink_detector.confidence_threshold = threshold;
+    state
+        .vr_state
+        .blink_wink
+        .blink_detector
+        .confidence_threshold = threshold;
     Some(format!(
         "(:type :response :id {} :status :ok :threshold {:.2})",
         msg_id, threshold
@@ -1404,11 +1714,7 @@ fn handle_gaze_zone_config(state: &mut EwwmState, msg_id: i64) -> Option<String>
     ))
 }
 
-fn handle_gaze_zone_set_dwell(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_zone_set_dwell(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let dwell_ms = match get_int(value, "dwell-ms") {
         Some(d) if d >= 50 && d <= 2000 => d as f64,
         _ => return Some(error_response(msg_id, "invalid :dwell-ms (50-2000)")),
@@ -1454,11 +1760,7 @@ fn handle_fatigue_reset(state: &mut EwwmState, msg_id: i64) -> Option<String> {
 
 // ── Auto-type handlers ─────────────────────────────────────
 
-fn handle_autotype(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_autotype(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let text = match get_string(value, "text") {
         Some(t) => t,
         None => return Some(error_response(msg_id, "missing :text")),
@@ -1498,11 +1800,7 @@ fn handle_autotype_abort(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     Some(ok_response(msg_id))
 }
 
-fn handle_autotype_pause(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_autotype_pause(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::autotype::PauseReason;
 
     let reason_str = get_keyword(value, "reason").unwrap_or_else(|| "user-requested".to_string());
@@ -1521,11 +1819,7 @@ fn handle_autotype_resume(state: &mut EwwmState, msg_id: i64) -> Option<String> 
 
 // ── Secure input handlers ──────────────────────────────────
 
-fn handle_secure_input_mode(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_secure_input_mode(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let enable = get_keyword(value, "enable")
         .map(|v| v != "nil")
         .unwrap_or(true);
@@ -1555,11 +1849,7 @@ fn handle_secure_input_status(state: &mut EwwmState, msg_id: i64) -> Option<Stri
     ))
 }
 
-fn handle_gaze_away_monitor(
-    _state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_away_monitor(_state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let enable = get_keyword(value, "enable")
         .map(|v| v != "nil")
         .unwrap_or(true);
@@ -1619,6 +1909,12 @@ fn handle_headless_set_resolution(
 
     state.headless_width = w;
     state.headless_height = h;
+    for cfg in &mut state.output_management_state.configs {
+        if cfg.name.starts_with("headless-") {
+            cfg.width = w;
+            cfg.height = h;
+        }
+    }
 
     debug!(w, h, "headless resolution updated");
     Some(format!(
@@ -1658,6 +1954,15 @@ fn handle_headless_add_output(state: &mut EwwmState, msg_id: i64) -> Option<Stri
     );
     output.set_preferred(mode);
     state.space.map_output(&output, (x_offset, 0));
+    let mut output_config =
+        crate::handlers::output_management::OutputConfig::new(format!("headless-{}", new_index));
+    output_config.x = x_offset;
+    output_config.width = state.headless_width;
+    output_config.height = state.headless_height;
+    output_config.refresh = 60_000;
+    state
+        .output_management_state
+        .upsert_detected_output(output_config);
 
     debug!(index = new_index, "added headless output");
     Some(format!(
@@ -1688,6 +1993,9 @@ fn handle_headless_remove_output(state: &mut EwwmState, msg_id: i64) -> Option<S
     if let Some(o) = output {
         state.space.unmap_output(&o);
     }
+    state
+        .output_management_state
+        .remove_detected_output(&target_name);
 
     debug!(index = removed_index, "removed headless output");
     Some(format!(
@@ -1705,11 +2013,7 @@ fn handle_dpms_get(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     ))
 }
 
-fn handle_dpms_set(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_dpms_set(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::handlers::dpms::DpmsState;
 
     let state_str = match get_string(value, "state") {
@@ -1724,10 +2028,7 @@ fn handle_dpms_set(
             debug!(?old, ?new_state, "DPMS state changed");
 
             // Notify Emacs of the state change
-            let event = format_event(
-                "dpms-changed",
-                &[("state", &new_state.to_string())],
-            );
+            let event = format_event("dpms-changed", &[("state", &new_state.to_string())]);
             IpcServer::broadcast_event(state, &event);
 
             Some(format!(
@@ -1737,7 +2038,10 @@ fn handle_dpms_set(
         }
         None => Some(error_response(
             msg_id,
-            &format!("invalid DPMS state: {} (use on/standby/suspend/off)", state_str),
+            &format!(
+                "invalid DPMS state: {} (use on/standby/suspend/off)",
+                state_str
+            ),
         )),
     }
 }
@@ -1759,10 +2063,7 @@ fn handle_screencopy_status(state: &mut EwwmState, msg_id: i64) -> Option<String
     };
     Some(format!(
         "(:type :response :id {} :status :ok :active-count {} :frame-counter {} :frames {})",
-        msg_id,
-        count,
-        state.screencopy_state.frame_counter,
-        frames_sexp,
+        msg_id, count, state.screencopy_state.frame_counter, frames_sexp,
     ))
 }
 
@@ -1782,17 +2083,11 @@ fn handle_output_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     };
     Some(format!(
         "(:type :response :id {} :status :ok :serial {} :outputs {})",
-        msg_id,
-        state.output_management_state.serial,
-        list_sexp,
+        msg_id, state.output_management_state.serial, list_sexp,
     ))
 }
 
-fn handle_output_configure(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_output_configure(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::handlers::output_management::{OutputConfig, OutputTransform};
 
     let name = match get_string(value, "name") {
@@ -1816,9 +2111,15 @@ fn handle_output_configure(
         enabled: get_bool(value, "enabled").unwrap_or(base.enabled),
         x: get_int(value, "x").map(|v| v as i32).unwrap_or(base.x),
         y: get_int(value, "y").map(|v| v as i32).unwrap_or(base.y),
-        width: get_int(value, "width").map(|v| v as i32).unwrap_or(base.width),
-        height: get_int(value, "height").map(|v| v as i32).unwrap_or(base.height),
-        refresh: get_int(value, "refresh").map(|v| v as i32).unwrap_or(base.refresh),
+        width: get_int(value, "width")
+            .map(|v| v as i32)
+            .unwrap_or(base.width),
+        height: get_int(value, "height")
+            .map(|v| v as i32)
+            .unwrap_or(base.height),
+        refresh: get_int(value, "refresh")
+            .map(|v| v as i32)
+            .unwrap_or(base.refresh),
         scale: get_float(value, "scale").unwrap_or(base.scale),
         transform: get_string(value, "transform")
             .and_then(|s| OutputTransform::from_str_ipc(&s))
@@ -1837,10 +2138,7 @@ fn handle_output_configure(
         match state.output_management_state.apply_config(config) {
             Ok(serial) => {
                 // Notify Emacs of the configuration change.
-                let event = format_event(
-                    "output-configured",
-                    &[("serial", &serial.to_string())],
-                );
+                let event = format_event("output-configured", &[("serial", &serial.to_string())]);
                 IpcServer::broadcast_event(state, &event);
 
                 Some(format!(
@@ -1877,11 +2175,7 @@ fn handle_gaze_scroll_status(state: &mut EwwmState, msg_id: i64) -> Option<Strin
     ))
 }
 
-fn handle_gaze_scroll_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gaze_scroll_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(enabled_str) = get_keyword(value, "enable") {
         state.vr_state.gaze_scroll.config.enabled = enabled_str != "nil";
     }
@@ -1926,11 +2220,7 @@ fn handle_gaze_scroll_set_speed(
 
 // ── Link hint handlers ─────────────────────────────────────
 
-fn handle_link_hints_load(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_link_hints_load(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let json = match get_string(value, "hints") {
         Some(j) => j,
         None => return Some(error_response(msg_id, "missing :hints (JSON array)")),
@@ -1948,12 +2238,12 @@ fn handle_link_hints_load(
 
 fn handle_link_hints_confirm(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     match state.vr_state.link_hints.confirm() {
-        Some(crate::vr::link_hints::LinkHintEvent::Confirmed { hint_id, url }) => {
-            Some(format!(
-                "(:type :response :id {} :status :ok :hint-id {} :url \"{}\")",
-                msg_id, hint_id, escape_string(&url)
-            ))
-        }
+        Some(crate::vr::link_hints::LinkHintEvent::Confirmed { hint_id, url }) => Some(format!(
+            "(:type :response :id {} :status :ok :hint-id {} :url \"{}\")",
+            msg_id,
+            hint_id,
+            escape_string(&url)
+        )),
         _ => Some(error_response(msg_id, "no hint currently highlighted")),
     }
 }
@@ -2006,11 +2296,7 @@ fn handle_hand_tracking_config(
     ))
 }
 
-fn handle_hand_tracking_joint(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_hand_tracking_joint(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let hand_str = match get_string(value, "hand") {
         Some(h) => h,
         None => return Some(error_response(msg_id, "missing :hand (left or right)")),
@@ -2020,7 +2306,11 @@ fn handle_hand_tracking_joint(
         None => return Some(error_response(msg_id, "missing :joint")),
     };
 
-    match state.vr_state.hand_tracking.get_joint(&hand_str, &joint_name) {
+    match state
+        .vr_state
+        .hand_tracking
+        .get_joint(&hand_str, &joint_name)
+    {
         Some(joint) => {
             let pos = joint.position;
             let rot = joint.orientation;
@@ -2066,7 +2356,10 @@ fn handle_hand_tracking_skeleton(
             sexp.push(')');
             Some(format!(
                 "(:type :response :id {} :status :ok :hand :{} :joint-count {} :joints {})",
-                msg_id, hand_str, joints.len(), sexp
+                msg_id,
+                hand_str,
+                joints.len(),
+                sexp
             ))
         }
         None => Some(error_response(
@@ -2119,11 +2412,7 @@ fn handle_gesture_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     ))
 }
 
-fn handle_gesture_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gesture_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(pinch) = get_float(value, "pinch-threshold") {
         state.vr_state.gesture.config.pinch_threshold_m = pinch as f32;
     }
@@ -2147,11 +2436,7 @@ fn handle_gesture_config(
     ))
 }
 
-fn handle_gesture_bind(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gesture_bind(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let gesture = match get_string(value, "gesture") {
         Some(g) => g,
         None => return Some(error_response(msg_id, "missing :gesture")),
@@ -2177,11 +2462,7 @@ fn handle_gesture_bind(
     ))
 }
 
-fn handle_gesture_unbind(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_gesture_unbind(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let gesture = match get_string(value, "gesture") {
         Some(g) => g,
         None => return Some(error_response(msg_id, "missing :gesture")),
@@ -2224,27 +2505,32 @@ fn handle_keyboard_hide(state: &mut EwwmState, msg_id: i64) -> Option<String> {
 
 fn handle_keyboard_toggle(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     state.vr_state.virtual_keyboard.toggle();
-    let visible = if state.vr_state.virtual_keyboard.visible { "t" } else { "nil" };
+    let visible = if state.vr_state.virtual_keyboard.visible {
+        "t"
+    } else {
+        "nil"
+    };
     Some(format!(
         "(:type :response :id {} :status :ok :visible {})",
         msg_id, visible
     ))
 }
 
-fn handle_keyboard_layout(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_keyboard_layout(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let layout_str = match get_string(value, "layout") {
         Some(l) => l,
         None => return Some(error_response(msg_id, "missing :layout")),
     };
 
-    match state.vr_state.virtual_keyboard.set_layout_by_name(&layout_str) {
+    match state
+        .vr_state
+        .virtual_keyboard
+        .set_layout_by_name(&layout_str)
+    {
         Ok(()) => Some(format!(
             "(:type :response :id {} :status :ok :layout \"{}\")",
-            msg_id, escape_string(&layout_str)
+            msg_id,
+            escape_string(&layout_str)
         )),
         Err(msg) => Some(error_response(
             msg_id,
@@ -2300,11 +2586,7 @@ fn handle_bci_signal_quality(state: &mut EwwmState, msg_id: i64) -> Option<Strin
     ))
 }
 
-fn handle_bci_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(board) = get_string(value, "board") {
         if let Err(e) = state.vr_state.bci.set_board_by_name(&board) {
             return Some(error_response(msg_id, &e));
@@ -2350,7 +2632,11 @@ fn handle_bci_inject_synthetic(
     if let Some(v) = get_string(value, "class") {
         params.push(("class".to_string(), v));
     }
-    match state.vr_state.bci.inject_synthetic_event(&event_type, &params) {
+    match state
+        .vr_state
+        .bci
+        .inject_synthetic_event(&event_type, &params)
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
@@ -2364,11 +2650,7 @@ fn handle_bci_data_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     ))
 }
 
-fn handle_bci_data_delete(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_data_delete(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let session_id = match get_string(value, "session-id") {
         Some(s) => s,
         None => return Some(error_response(msg_id, "missing :session-id")),
@@ -2411,18 +2693,12 @@ fn handle_bci_attention_config(
     ))
 }
 
-fn handle_bci_attention_calibrate_start(
-    state: &mut EwwmState,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_bci_attention_calibrate_start(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     state.vr_state.bci.attention.start_calibration();
     Some(ok_response(msg_id))
 }
 
-fn handle_bci_attention_calibrate_finish(
-    state: &mut EwwmState,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_bci_attention_calibrate_finish(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     match state.vr_state.bci.attention.finish_calibration() {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
@@ -2439,11 +2715,7 @@ fn handle_bci_ssvep_status(state: &mut EwwmState, msg_id: i64) -> Option<String>
     ))
 }
 
-fn handle_bci_ssvep_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_ssvep_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(enabled) = get_bool(value, "enabled") {
         state.vr_state.bci.ssvep.config.enabled = enabled;
     }
@@ -2483,11 +2755,7 @@ fn handle_bci_p300_status(state: &mut EwwmState, msg_id: i64) -> Option<String> 
     ))
 }
 
-fn handle_bci_p300_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_p300_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(enabled) = get_bool(value, "enabled") {
         state.vr_state.bci.p300.config.enabled = enabled;
     }
@@ -2507,11 +2775,7 @@ fn handle_bci_p300_config(
     ))
 }
 
-fn handle_bci_p300_start(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_p300_start(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let num_targets = get_int(value, "num-targets").unwrap_or(6) as usize;
     state.vr_state.bci.p300.start(num_targets);
     Some(ok_response(msg_id))
@@ -2532,11 +2796,7 @@ fn handle_bci_mi_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     ))
 }
 
-fn handle_bci_mi_config(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_bci_mi_config(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     if let Some(enabled) = get_bool(value, "enabled") {
         state.vr_state.bci.motor_imagery.config.enabled = enabled;
     }
@@ -2550,18 +2810,12 @@ fn handle_bci_mi_config(
     ))
 }
 
-fn handle_bci_mi_calibrate_start(
-    state: &mut EwwmState,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_bci_mi_calibrate_start(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     state.vr_state.bci.motor_imagery.start_calibration();
     Some(ok_response(msg_id))
 }
 
-fn handle_bci_mi_calibrate_finish(
-    state: &mut EwwmState,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_bci_mi_calibrate_finish(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     match state.vr_state.bci.motor_imagery.finish_calibration() {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
@@ -2607,11 +2861,7 @@ fn handle_bci_fatigue_eeg_config(
 
 // ── IPC recording handlers ─────────────────────────────────
 
-fn handle_ipc_record_start(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_ipc_record_start(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let session_name = get_string(value, "session-name");
     state.ipc_server.recorder.start(session_name);
     Some(format!("(:type :response :id {} :status :ok)", msg_id))
@@ -2636,14 +2886,16 @@ fn handle_ipc_record_status(state: &mut EwwmState, msg_id: i64) -> Option<String
 
 // ── IPC security handlers ────────────────────────────────
 
-fn handle_ipc_client_info(
-    state: &mut EwwmState,
-    client_id: u64,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_ipc_client_info(state: &mut EwwmState, client_id: u64, msg_id: i64) -> Option<String> {
     if let Some(client) = state.ipc_server.clients.get(&client_id) {
-        let uid = client.peer_uid.map(|u| u.to_string()).unwrap_or_else(|| "nil".to_string());
-        let pid = client.peer_pid.map(|p| p.to_string()).unwrap_or_else(|| "nil".to_string());
+        let uid = client
+            .peer_uid
+            .map(|u| u.to_string())
+            .unwrap_or_else(|| "nil".to_string());
+        let pid = client
+            .peer_pid
+            .map(|p| p.to_string())
+            .unwrap_or_else(|| "nil".to_string());
         let rate = client.rate_limiter.max_per_second;
         Some(format!(
             "(:type :response :id {} :status :ok :client-id {} :peer-uid {} :peer-pid {} :authenticated t :rate-limit {})",
@@ -2721,11 +2973,7 @@ fn handle_vr_follow_grab_all(state: &mut EwwmState, msg_id: i64) -> Option<Strin
 
 // ── VR Transient Chains ──────────────────────────────────
 
-fn handle_vr_transient_add(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_transient_add(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::transient_3d::TransientPlacement;
 
     let child_id = match get_int(value, "child") {
@@ -2737,19 +2985,20 @@ fn handle_vr_transient_add(
         None => return Some(error_response(msg_id, "missing :parent")),
     };
     let placement_str = get_keyword(value, "placement").unwrap_or_else(|| "auto".to_string());
-    let placement = TransientPlacement::from_str(&placement_str).unwrap_or(TransientPlacement::Auto);
+    let placement =
+        TransientPlacement::from_str(&placement_str).unwrap_or(TransientPlacement::Auto);
 
-    match state.vr_state.transient_chains.add_transient(child_id, parent_id, placement) {
+    match state
+        .vr_state
+        .transient_chains
+        .add_transient(child_id, parent_id, placement)
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
 }
 
-fn handle_vr_transient_remove(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_transient_remove(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let child_id = match get_int(value, "child") {
         Some(id) => id as u64,
         None => return Some(error_response(msg_id, "missing :child")),
@@ -2768,11 +3017,7 @@ fn handle_vr_transient_list(state: &mut EwwmState, msg_id: i64) -> Option<String
 
 // ── VR Overlays ─────────────────────────────────────────────
 
-fn handle_vr_overlay_create(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_overlay_create(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::overlay::OverlayType;
 
     let type_str = get_keyword(value, "overlay-type").unwrap_or_else(|| "head-locked".to_string());
@@ -2790,10 +3035,13 @@ fn handle_vr_overlay_create(
     let alpha = get_float(value, "alpha").unwrap_or(1.0) as f32;
     let sort_order = get_int(value, "sort-order").unwrap_or(0) as i32;
 
-    let id = state
-        .vr_state
-        .overlay_manager
-        .create_overlay(overlay_type, width, height, alpha, sort_order);
+    let id = state.vr_state.overlay_manager.create_overlay(
+        overlay_type,
+        width,
+        height,
+        alpha,
+        sort_order,
+    );
 
     if id == 0 {
         Some(error_response(msg_id, "max overlays reached"))
@@ -2805,11 +3053,7 @@ fn handle_vr_overlay_create(
     }
 }
 
-fn handle_vr_overlay_remove(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_overlay_remove(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let overlay_id = match get_int(value, "overlay-id") {
         Some(id) => id as u64,
         None => return Some(error_response(msg_id, "missing :overlay-id")),
@@ -2897,11 +3141,7 @@ fn handle_vr_radial_toggle(state: &mut EwwmState, msg_id: i64) -> Option<String>
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_radial_configure(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_radial_configure(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     // Apply radius if provided.
     if let Some(radius) = get_float(value, "radius") {
         state.vr_state.radial_menu.radius = radius as f32;
@@ -2948,11 +3188,7 @@ fn handle_vr_radial_status(state: &mut EwwmState, msg_id: i64) -> Option<String>
 
 // ── VR Capture Visibility ───────────────────────────────────
 
-fn handle_vr_capture_set(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_capture_set(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     use crate::vr::capture_visibility::CaptureVisibility;
 
     let surface_id = match get_int(value, "surface") {
@@ -2977,11 +3213,7 @@ fn handle_vr_capture_set(
     Some(ok_response(msg_id))
 }
 
-fn handle_vr_capture_get(
-    state: &mut EwwmState,
-    msg_id: i64,
-    value: &Value,
-) -> Option<String> {
+fn handle_vr_capture_get(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {
     let surface_id = match get_int(value, "surface") {
         Some(id) => id as u64,
         None => return Some(error_response(msg_id, "missing :surface")),
@@ -2989,7 +3221,9 @@ fn handle_vr_capture_get(
     let vis = state.vr_state.capture_visibility.get_visibility(surface_id);
     Some(format!(
         "(:type :response :id {} :status :ok :surface {} :visibility :{})",
-        msg_id, surface_id, vis.as_str()
+        msg_id,
+        surface_id,
+        vis.as_str()
     ))
 }
 
@@ -3126,10 +3360,7 @@ fn handle_beyond_set_led_color(
     }
 }
 
-fn handle_beyond_firmware_version(
-    state: &mut EwwmState,
-    msg_id: i64,
-) -> Option<String> {
+fn handle_beyond_firmware_version(state: &mut EwwmState, msg_id: i64) -> Option<String> {
     let version = state.vr_state.beyond_hid.firmware_version_str();
     Some(format!(
         "(:type :response :id {} :status :ok :firmware-version \"{}\")",
@@ -3191,6 +3422,14 @@ fn escape_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+fn quoted_list(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("\"{}\"", escape_string(value)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Extract a keyword value from an s-expression plist.
 /// Walks cons pairs directly to find `:key` followed by its value.
 /// Handles both `Value::Keyword("key")` (elisp parser) and
@@ -3219,9 +3458,7 @@ fn get_keyword(value: &Value, key: &str) -> Option<String> {
                             }
                             Value::String(v) => Some(v.to_string()),
                             Value::Number(n) => Some(n.to_string()),
-                            Value::Bool(b) => {
-                                Some(if *b { "t" } else { "nil" }.to_string())
-                            }
+                            Value::Bool(b) => Some(if *b { "t" } else { "nil" }.to_string()),
                             Value::Null => Some("nil".to_string()),
                             _ => Some(val.to_string()),
                         };
@@ -3449,21 +3686,30 @@ mod tests {
     fn test_ok_response_is_valid_sexp() {
         let r = ok_response(1);
         let parsed = lexpr::from_str(&r);
-        assert!(parsed.is_ok(), "ok_response should produce valid s-expression");
+        assert!(
+            parsed.is_ok(),
+            "ok_response should produce valid s-expression"
+        );
     }
 
     #[test]
     fn test_error_response_is_valid_sexp() {
         let r = error_response(1, "test error");
         let parsed = lexpr::from_str(&r);
-        assert!(parsed.is_ok(), "error_response should produce valid s-expression");
+        assert!(
+            parsed.is_ok(),
+            "error_response should produce valid s-expression"
+        );
     }
 
     #[test]
     fn test_format_event_is_valid_sexp() {
         let e = format_event("test", &[("key", "123")]);
         let parsed = lexpr::from_str(&e);
-        assert!(parsed.is_ok(), "format_event should produce valid s-expression");
+        assert!(
+            parsed.is_ok(),
+            "format_event should produce valid s-expression"
+        );
     }
 
     #[test]

--- a/compositor/src/ipc/recorder.rs
+++ b/compositor/src/ipc/recorder.rs
@@ -52,10 +52,7 @@ pub struct RecordedMessage {
 impl RecordedMessage {
     /// Serialize to a simple s-expression format.
     pub fn to_sexp(&self) -> String {
-        let escaped = self
-            .payload
-            .replace('\\', "\\\\")
-            .replace('"', "\\\"");
+        let escaped = self.payload.replace('\\', "\\\\").replace('"', "\\\"");
         format!(
             "(:timestamp {} :client {} :direction :{} :payload \"{}\")",
             self.timestamp_ms,
@@ -103,12 +100,7 @@ impl IpcRecorder {
     }
 
     /// Record a message if recording is active.
-    pub fn record(
-        &mut self,
-        client_id: u64,
-        direction: MessageDirection,
-        payload: &str,
-    ) {
+    pub fn record(&mut self, client_id: u64, direction: MessageDirection, payload: &str) {
         if !self.active {
             return;
         }
@@ -244,11 +236,7 @@ mod tests {
     fn test_recorder_to_sexp() {
         let mut rec = IpcRecorder::new();
         rec.start(Some("demo".to_string()));
-        rec.record(
-            1,
-            MessageDirection::Request,
-            "(:type :ping :id 1)",
-        );
+        rec.record(1, MessageDirection::Request, "(:type :ping :id 1)");
         let sexp = rec.to_sexp();
         assert!(sexp.contains(":session-name \"demo\""));
         assert!(sexp.contains(":message-count 1"));

--- a/compositor/src/ipc/server.rs
+++ b/compositor/src/ipc/server.rs
@@ -328,21 +328,19 @@ impl IpcServer {
                 if state.ipc_server.ipc_trace {
                     info!(client_id, "<< {}", msg_str);
                 }
-                state.ipc_server.recorder.record(
-                    client_id,
-                    MessageDirection::Request,
-                    &msg_str,
-                );
+                state
+                    .ipc_server
+                    .recorder
+                    .record(client_id, MessageDirection::Request, &msg_str);
                 let response = dispatch::handle_message(state, client_id, &msg_str);
                 if let Some(ref resp) = response {
                     if state.ipc_server.ipc_trace {
                         info!(client_id, ">> {}", resp);
                     }
-                    state.ipc_server.recorder.record(
-                        client_id,
-                        MessageDirection::Response,
-                        resp,
-                    );
+                    state
+                        .ipc_server
+                        .recorder
+                        .record(client_id, MessageDirection::Response, resp);
                     if let Some(client) = state.ipc_server.clients.get_mut(&client_id) {
                         client.enqueue_message(resp);
                     }
@@ -370,11 +368,10 @@ impl IpcServer {
         if state.ipc_server.ipc_trace {
             info!("broadcast >> {}", event);
         }
-        state.ipc_server.recorder.record(
-            0,
-            MessageDirection::Event,
-            event,
-        );
+        state
+            .ipc_server
+            .recorder
+            .record(0, MessageDirection::Event, event);
         for client in state.ipc_server.clients.values_mut() {
             if client.authenticated {
                 client.enqueue_event(event);

--- a/compositor/src/main.rs
+++ b/compositor/src/main.rs
@@ -2,9 +2,10 @@
 //!
 //! Part of the EXWM-VR project: a transhuman Emacs window manager.
 
-use ewwm_compositor::backend;
+use ewwm_compositor::{backend, config::CompositorConfig};
 
 use clap::Parser;
+use std::path::PathBuf;
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -34,6 +35,10 @@ struct Cli {
     #[arg(long)]
     ipc_socket: Option<String>,
 
+    /// Native compositor config file (default: $XDG_CONFIG_HOME/exwm-vr/compositor.json)
+    #[arg(long)]
+    config: Option<PathBuf>,
+
     /// Log all IPC messages to stderr
     #[arg(long)]
     ipc_trace: bool,
@@ -61,6 +66,23 @@ fn main() -> anyhow::Result<()> {
 
     info!("ewwm-compositor v{} starting", env!("CARGO_PKG_VERSION"));
     info!("backend: {}", cli.backend);
+
+    let compositor_config = if let Some(path) = &cli.config {
+        let path_text = path.to_string_lossy();
+        let cfg = CompositorConfig::load_from_file(path_text.as_ref())
+            .map_err(|err| anyhow::anyhow!("failed to load config {}: {}", path.display(), err))?;
+        info!("config: loaded from {}", path.display());
+        cfg
+    } else {
+        CompositorConfig::load_or_default()
+    };
+    info!(
+        config_default_path = %CompositorConfig::config_path().display(),
+        config_override_path = ?cli.config,
+        config_ipc_socket = ?compositor_config.ipc_socket_path,
+        config_vr_enabled = compositor_config.vr_enabled,
+        "native compositor config initialized"
+    );
 
     let backend_type = match cli.backend.as_str() {
         #[cfg(feature = "full-backend")]
@@ -101,16 +123,15 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Parse headless resolution
-    let (h_width, h_height) = backend::headless::HeadlessConfig::parse_resolution(
-        &cli.headless_resolution,
-    )
-    .unwrap_or_else(|| {
-        eprintln!(
-            "Invalid headless resolution '{}', using 1920x1080",
-            cli.headless_resolution
-        );
-        (1920, 1080)
-    });
+    let (h_width, h_height) =
+        backend::headless::HeadlessConfig::parse_resolution(&cli.headless_resolution)
+            .unwrap_or_else(|| {
+                eprintln!(
+                    "Invalid headless resolution '{}', using 1920x1080",
+                    cli.headless_resolution
+                );
+                (1920, 1080)
+            });
 
     let headless_config = backend::headless::HeadlessConfig {
         output_count: cli.headless_outputs,
@@ -119,7 +140,10 @@ fn main() -> anyhow::Result<()> {
         poll_interval_ms: 100,
     };
 
-    let ipc_socket = cli.ipc_socket.map(std::path::PathBuf::from);
+    let ipc_socket = cli
+        .ipc_socket
+        .map(PathBuf::from)
+        .or_else(|| compositor_config.ipc_socket_pathbuf());
 
     backend::run(
         backend_type,
@@ -128,5 +152,6 @@ fn main() -> anyhow::Result<()> {
         headless_config,
         ipc_socket,
         cli.ipc_trace,
+        compositor_config,
     )
 }

--- a/compositor/src/state.rs
+++ b/compositor/src/state.rs
@@ -3,6 +3,12 @@
 //! Follows niri pattern: single `EwwmState` struct owns everything,
 //! passed as `&mut self` to all handler trait implementations.
 
+#[cfg(feature = "full-backend")]
+use smithay::{
+    backend::drm::{DrmDevice, DrmNode},
+    reexports::drm::control::crtc,
+    wayland::drm_lease::{DrmLease, DrmLeaseState},
+};
 use smithay::{
     desktop::{PopupManager, Space, Window},
     input::{Seat, SeatState},
@@ -14,7 +20,7 @@ use smithay::{
             Client, Display, DisplayHandle,
         },
     },
-    utils::Rectangle,
+    utils::{Logical, Rectangle},
     wayland::{
         compositor::{CompositorClientState, CompositorState},
         cursor_shape::CursorShapeManagerState,
@@ -23,41 +29,31 @@ use smithay::{
         idle_inhibit::IdleInhibitManagerState,
         idle_notify::IdleNotifierState,
         output::OutputManagerState,
-        selection::{
-            data_device::DataDeviceState,
-            primary_selection::PrimarySelectionState,
-        },
-        session_lock::SessionLockManagerState,
-        shell::{
-            wlr_layer::WlrLayerShellState,
-            xdg::XdgShellState,
-        },
         pointer_constraints::PointerConstraintsState,
+        selection::{data_device::DataDeviceState, primary_selection::PrimarySelectionState},
+        session_lock::SessionLockManagerState,
+        shell::{wlr_layer::WlrLayerShellState, xdg::XdgShellState},
         shm::ShmState,
         xdg_activation::XdgActivationState,
     },
 };
-#[cfg(feature = "full-backend")]
-use smithay::{
-    backend::drm::{DrmDevice, DrmNode},
-    reexports::drm::control::crtc,
-    wayland::drm_lease::{DrmLease, DrmLeaseState},
-};
 #[cfg(feature = "xwayland")]
-use smithay::{
-    wayland::xwayland_shell::XWaylandShellState,
-    xwayland::xwm::X11Wm,
-};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::{atomic::{AtomicU64, Ordering}, Arc},
-};
+use smithay::{wayland::xwayland_shell::XWaylandShellState, xwayland::xwm::X11Wm};
 #[cfg(feature = "full-backend")]
 use std::{cell::RefCell, rc::Rc};
+use std::{
+    collections::{HashMap, HashSet},
+    process::{Child, Command},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 use tracing::info;
 
 use crate::autotype::AutoTypeManager;
 use crate::clock::{Clock, SystemClock};
+use crate::config::CompositorConfig;
 use crate::handlers::dpms::DpmsState;
 use crate::handlers::output_management::OutputManagementState;
 use crate::handlers::screencopy::ScreencopyState;
@@ -89,6 +85,10 @@ pub struct SurfaceData {
     pub workspace: usize,
     /// Whether this surface is floating (vs tiled).
     pub floating: bool,
+    /// Last native compositor geometry for remapping/reflow.
+    pub geometry: Rectangle<i32, Logical>,
+    /// Whether this surface is currently mapped into the compositor space.
+    pub visible: bool,
 }
 
 impl SurfaceData {
@@ -102,6 +102,8 @@ impl SurfaceData {
             x11_instance: None,
             workspace: 0,
             floating: false,
+            geometry: Rectangle::new((0, 0).into(), (800, 600).into()),
+            visible: true,
         }
     }
 
@@ -134,6 +136,9 @@ impl Default for UsableArea {
 
 /// Central compositor state.
 pub struct EwwmState {
+    // Native compositor config
+    pub config: CompositorConfig,
+
     // Wayland core
     pub display_handle: DisplayHandle,
     pub loop_handle: LoopHandle<'static, Self>,
@@ -191,7 +196,9 @@ pub struct EwwmState {
     pub surfaces: HashMap<u64, SurfaceData>,
     /// Maps surface_id → Window for O(1) dispatch lookups.
     pub surface_to_window: HashMap<u64, Window>,
+    pub workspace_count: usize,
     pub active_workspace: usize,
+    pub current_layout: String,
 
     // Output usable area (after layer-shell exclusive zones)
     pub usable_area: UsableArea,
@@ -199,6 +206,9 @@ pub struct EwwmState {
     // IPC
     pub ipc_server: IpcServer,
     pub grabbed_keys: HashSet<String>,
+    pub autostart_launched: HashSet<String>,
+    pub session_lock_child: Option<Child>,
+    pub session_idle_child: Option<Child>,
 
     // VR subsystem
     pub vr_state: VrState,
@@ -262,9 +272,14 @@ pub enum CursorImageStatus {
 }
 
 impl EwwmState {
-    pub fn new(
+    pub fn new(display: &mut Display<Self>, loop_handle: LoopHandle<'static, Self>) -> Self {
+        Self::new_with_config(display, loop_handle, CompositorConfig::default())
+    }
+
+    pub fn new_with_config(
         display: &mut Display<Self>,
         loop_handle: LoopHandle<'static, Self>,
+        config: CompositorConfig,
     ) -> Self {
         let display_handle = display.handle();
 
@@ -279,12 +294,10 @@ impl EwwmState {
         let layer_shell_state = WlrLayerShellState::new::<Self>(&display_handle);
 
         // Session lock protocol (ext-session-lock-v1)
-        let session_lock_state =
-            SessionLockManagerState::new::<Self, _>(&display_handle, |_| true);
+        let session_lock_state = SessionLockManagerState::new::<Self, _>(&display_handle, |_| true);
 
         // Idle notification (ext-idle-notify-v1)
-        let idle_notifier_state =
-            IdleNotifierState::new(&display_handle, loop_handle.clone());
+        let idle_notifier_state = IdleNotifierState::new(&display_handle, loop_handle.clone());
 
         // Idle inhibit (zwp-idle-inhibit-v1)
         let idle_inhibit_state = IdleInhibitManagerState::new::<Self>(&display_handle);
@@ -309,8 +322,7 @@ impl EwwmState {
         let xwayland_shell_state = XWaylandShellState::new::<Self>(&display_handle);
 
         // Pointer constraints (pointer-constraints-unstable-v1)
-        let pointer_constraints_state =
-            PointerConstraintsState::new::<Self>(&display_handle);
+        let pointer_constraints_state = PointerConstraintsState::new::<Self>(&display_handle);
 
         let seat = seat_state.new_wl_seat(&display_handle, "ewwm-seat");
 
@@ -327,7 +339,12 @@ impl EwwmState {
 
         let ipc_socket_path = IpcServer::default_socket_path();
 
+        let workspace_count = config.normalized_workspace_count();
+        let active_workspace = config.normalized_active_workspace();
+        let current_layout = config.layout_mode.clone();
+
         Self {
+            config,
             display_handle,
             loop_handle,
             compositor_state,
@@ -357,10 +374,15 @@ impl EwwmState {
             space: Space::default(),
             surfaces: HashMap::new(),
             surface_to_window: HashMap::new(),
-            active_workspace: 0,
+            workspace_count,
+            active_workspace,
+            current_layout,
             usable_area: UsableArea::default(),
             ipc_server: IpcServer::new(ipc_socket_path),
             grabbed_keys: HashSet::new(),
+            autostart_launched: HashSet::new(),
+            session_lock_child: None,
+            session_idle_child: None,
             vr_state: VrState::new(),
             autotype: AutoTypeManager::new(),
             secure_input: SecureInputState::new(),
@@ -407,11 +429,7 @@ impl EwwmState {
     }
 
     #[cfg(feature = "full-backend")]
-    pub fn register_drm_lease_device(
-        &mut self,
-        node: DrmNode,
-        drm: Rc<RefCell<DrmDevice>>,
-    ) {
+    pub fn register_drm_lease_device(&mut self, node: DrmNode, drm: Rc<RefCell<DrmDevice>>) {
         self.drm_lease_devices.insert(node, drm);
     }
 
@@ -435,14 +453,379 @@ impl EwwmState {
         self.surface_to_window.get(&surface_id)
     }
 
+    /// Initial visible rectangle for newly mapped application windows.
+    pub fn initial_window_geometry(&self) -> Rectangle<i32, Logical> {
+        let area = self.usable_area;
+        let width = if area.w > 0 { area.w } else { 1920 };
+        let height = if area.h > 0 { area.h } else { 1080 };
+        Rectangle::new((area.x, area.y).into(), (width, height).into())
+    }
+
+    pub fn set_surface_geometry(&mut self, surface_id: u64, geometry: Rectangle<i32, Logical>) {
+        if let Some(data) = self.surfaces.get_mut(&surface_id) {
+            data.geometry = geometry;
+        }
+
+        if let Some(window) = self.surface_to_window.get(&surface_id).cloned() {
+            self.space
+                .map_element(window.clone(), (geometry.loc.x, geometry.loc.y), false);
+            if let Some(toplevel) = window.toplevel() {
+                toplevel.with_pending_state(|state| {
+                    state.size = Some((geometry.size.w, geometry.size.h).into());
+                });
+                toplevel.send_pending_configure();
+            }
+            #[cfg(feature = "xwayland")]
+            if let Some(x11) = window.x11_surface() {
+                let _ = x11.configure(Some(geometry));
+            }
+        }
+    }
+
+    pub fn apply_workspace_visibility(&mut self) {
+        let surface_ids: Vec<u64> = self.surfaces.keys().copied().collect();
+        for surface_id in surface_ids {
+            let should_show = self
+                .surfaces
+                .get(&surface_id)
+                .map(|data| data.workspace == self.active_workspace)
+                .unwrap_or(false);
+            let window = self.surface_to_window.get(&surface_id).cloned();
+
+            if should_show {
+                let geometry = self
+                    .surfaces
+                    .get(&surface_id)
+                    .map(|data| data.geometry)
+                    .unwrap_or_else(|| self.initial_window_geometry());
+                if let Some(window) = window {
+                    self.space
+                        .map_element(window, (geometry.loc.x, geometry.loc.y), false);
+                }
+                if let Some(data) = self.surfaces.get_mut(&surface_id) {
+                    data.visible = true;
+                }
+            } else {
+                if let Some(window) = window {
+                    self.space.unmap_elem(&window);
+                }
+                if let Some(data) = self.surfaces.get_mut(&surface_id) {
+                    data.visible = false;
+                }
+            }
+        }
+    }
+
+    pub fn reflow_native_layout(&mut self) {
+        self.apply_workspace_visibility();
+        let mut tiled: Vec<u64> = self
+            .surfaces
+            .iter()
+            .filter_map(|(id, data)| {
+                (data.workspace == self.active_workspace && !data.floating).then_some(*id)
+            })
+            .collect();
+        tiled.sort_unstable();
+        if tiled.is_empty() {
+            return;
+        }
+
+        let rects = self.layout_rects(tiled.len());
+        for (surface_id, geometry) in tiled.into_iter().zip(rects) {
+            self.set_surface_geometry(surface_id, geometry);
+        }
+    }
+
+    fn layout_rects(&self, count: usize) -> Vec<Rectangle<i32, Logical>> {
+        let area = self.usable_area;
+        let x = area.x;
+        let y = area.y;
+        let w = if area.w > 0 { area.w } else { 1920 };
+        let h = if area.h > 0 { area.h } else { 1080 };
+
+        match self.current_layout.as_str() {
+            "monocle" => (0..count)
+                .map(|_| Rectangle::new((x, y).into(), (w, h).into()))
+                .collect(),
+            "grid" => {
+                let cols = (count as f64).sqrt().ceil() as i32;
+                let rows = ((count as f64) / cols as f64).ceil() as i32;
+                let cell_w = (w / cols.max(1)).max(1);
+                let cell_h = (h / rows.max(1)).max(1);
+                (0..count)
+                    .map(|index| {
+                        let index = index as i32;
+                        let col = index % cols;
+                        let row = index / cols;
+                        Rectangle::new(
+                            (x + col * cell_w, y + row * cell_h).into(),
+                            (cell_w, cell_h).into(),
+                        )
+                    })
+                    .collect()
+            }
+            _ if count == 1 => vec![Rectangle::new((x, y).into(), (w, h).into())],
+            _ => {
+                let master_w = ((w as f32) * 0.55).round() as i32;
+                let stack_w = (w - master_w).max(1);
+                let stack_count = (count as i32 - 1).max(1);
+                let stack_h = (h / stack_count).max(1);
+                let mut rects = Vec::with_capacity(count);
+                rects.push(Rectangle::new((x, y).into(), (master_w, h).into()));
+                for index in 1..count {
+                    let row = index as i32 - 1;
+                    rects.push(Rectangle::new(
+                        (x + master_w, y + row * stack_h).into(),
+                        (stack_w, stack_h).into(),
+                    ));
+                }
+                rects
+            }
+        }
+    }
+
+    pub fn set_native_layout(&mut self, layout: &str) {
+        self.current_layout = layout.to_string();
+        self.reflow_native_layout();
+    }
+
+    pub fn cycle_native_layout(&mut self) {
+        let next = match self.current_layout.as_str() {
+            "tiling" => "monocle",
+            "monocle" => "grid",
+            "grid" => "tiling",
+            _ => "tiling",
+        };
+        self.set_native_layout(next);
+    }
+
+    pub fn reload_native_config(&mut self) -> Result<(), String> {
+        let config = CompositorConfig::load_or_default();
+        self.workspace_count = config.normalized_workspace_count();
+        self.active_workspace = config.normalized_active_workspace();
+        self.current_layout = config.layout_mode.clone();
+        self.config = config;
+        self.reflow_native_layout();
+        Ok(())
+    }
+
+    pub fn launch_configured_app(&mut self, target: &str) -> Result<u32, String> {
+        let command = self
+            .config
+            .app_launch_commands
+            .get(target)
+            .cloned()
+            .ok_or_else(|| format!("unknown app launch target: {target}"))?;
+        let child = Command::new("sh")
+            .arg("-lc")
+            .arg(&command)
+            .spawn()
+            .map_err(|err| format!("failed to launch {target}: {err}"))?;
+        let pid = child.id();
+        info!(target, command, pid, "native app launch");
+        Ok(pid)
+    }
+
+    pub fn run_autostart(&mut self, force: bool) -> (Vec<String>, Vec<String>, Vec<String>) {
+        let mut launched = Vec::new();
+        let mut skipped = Vec::new();
+        let mut errors = Vec::new();
+        for target in self.config.autostart_targets.clone() {
+            if !force && self.autostart_launched.contains(&target) {
+                skipped.push(target);
+                continue;
+            }
+            match self.launch_configured_app(&target) {
+                Ok(_) => {
+                    self.autostart_launched.insert(target.clone());
+                    launched.push(target);
+                }
+                Err(err) => errors.push(err),
+            }
+        }
+        (launched, skipped, errors)
+    }
+
+    pub fn apply_real_session_startup_policy(&mut self) {
+        if self.config.autostart_enabled {
+            let (launched, skipped, errors) = self.run_autostart(false);
+            info!(?launched, ?skipped, ?errors, "native autostart policy");
+        }
+        if self.config.session_idle_enabled {
+            if let Err(err) = self.start_session_idle() {
+                info!(error = err, "native idle supervision not started");
+            }
+        }
+    }
+
+    pub fn start_session_lock(&mut self) -> Result<(), String> {
+        if Self::child_running(&mut self.session_lock_child) {
+            return Ok(());
+        }
+        let command = self
+            .config
+            .session_lock_command
+            .clone()
+            .ok_or_else(|| "session_lock_command is not configured".to_string())?;
+        let child = Command::new("sh")
+            .arg("-lc")
+            .arg(&command)
+            .spawn()
+            .map_err(|err| format!("failed to launch session lock: {err}"))?;
+        self.session_locked = true;
+        self.session_lock_child = Some(child);
+        Ok(())
+    }
+
+    pub fn start_session_idle(&mut self) -> Result<(), String> {
+        if Self::child_running(&mut self.session_idle_child) {
+            return Ok(());
+        }
+        let command = self
+            .config
+            .session_idle_command
+            .clone()
+            .ok_or_else(|| "session_idle_command is not configured".to_string())?;
+        let child = Command::new("sh")
+            .arg("-lc")
+            .arg(&command)
+            .spawn()
+            .map_err(|err| format!("failed to launch session idle command: {err}"))?;
+        self.session_idle_child = Some(child);
+        Ok(())
+    }
+
+    pub fn stop_session_idle(&mut self) -> Result<(), String> {
+        if let Some(child) = self.session_idle_child.as_mut() {
+            child
+                .kill()
+                .map_err(|err| format!("failed to stop session idle command: {err}"))?;
+        }
+        self.session_idle_child = None;
+        Ok(())
+    }
+
+    pub fn child_running(child: &mut Option<Child>) -> bool {
+        child
+            .as_mut()
+            .map(|child| child.try_wait().ok().flatten().is_none())
+            .unwrap_or(false)
+    }
+
+    pub fn handle_native_key_action(&mut self, key: &str) -> bool {
+        let action = match self.config.key_actions.get(key).cloned() {
+            Some(action) => action,
+            None => return false,
+        };
+        let ok = self.run_native_action(&action).is_ok();
+        let safe_key = key.replace('"', "\\\"");
+        let safe_action = action.replace('"', "\\\"");
+        let event = crate::ipc::dispatch::format_event(
+            "native-key-action",
+            &[
+                ("key", &format!("\"{}\"", safe_key)),
+                ("action", &format!("\"{}\"", safe_action)),
+                ("status", if ok { ":ok" } else { ":error" }),
+            ],
+        );
+        crate::ipc::server::IpcServer::broadcast_event(self, &event);
+        true
+    }
+
+    pub fn run_native_action(&mut self, action: &str) -> Result<(), String> {
+        if let Some(workspace) = action.strip_prefix("workspace-switch:") {
+            let workspace = workspace
+                .parse::<usize>()
+                .map_err(|_| format!("invalid workspace action: {action}"))?;
+            if workspace >= self.workspace_count {
+                return Err(format!(
+                    "workspace {} out of range (count {})",
+                    workspace, self.workspace_count
+                ));
+            }
+            self.active_workspace = workspace;
+            self.reflow_native_layout();
+            return Ok(());
+        }
+        if let Some(target) = action.strip_prefix("app-launch:") {
+            self.launch_configured_app(target)?;
+            return Ok(());
+        }
+        if let Some(layout) = action.strip_prefix("layout-set:") {
+            self.set_native_layout(layout);
+            return Ok(());
+        }
+        match action {
+            "focus-next" => self.focus_next_surface(1),
+            "focus-previous" => self.focus_next_surface(-1),
+            "layout-cycle" => {
+                self.cycle_native_layout();
+                Ok(())
+            }
+            "config-reload" => self.reload_native_config(),
+            "compositor-exit" => {
+                self.running = false;
+                Ok(())
+            }
+            _ => Err(format!("unknown native key action: {action}")),
+        }
+    }
+
+    fn focus_next_surface(&mut self, direction: i32) -> Result<(), String> {
+        let mut ids: Vec<u64> = self
+            .surfaces
+            .iter()
+            .filter_map(|(id, data)| (data.workspace == self.active_workspace).then_some(*id))
+            .collect();
+        ids.sort_unstable();
+        if ids.is_empty() {
+            return Err("no focusable surfaces on active workspace".to_string());
+        }
+        let current = self
+            .focused_surface
+            .and_then(|id| ids.iter().position(|candidate| *candidate == id))
+            .unwrap_or(0);
+        let len = ids.len() as i32;
+        let next = (current as i32 + direction).rem_euclid(len) as usize;
+        self.focus_surface(ids[next]);
+        Ok(())
+    }
+
+    pub fn focus_surface(&mut self, surface_id: u64) {
+        if let Some(window) = self.surface_to_window.get(&surface_id).cloned() {
+            self.space.raise_element(&window, true);
+            if let Some(keyboard) = self.seat.get_keyboard() {
+                let serial = smithay::utils::SERIAL_COUNTER.next_serial();
+                let wl_surface = window.toplevel().map(|t| t.wl_surface().clone());
+                if let Some(surface) = wl_surface {
+                    keyboard.set_focus(self, Some(surface), serial);
+                }
+            }
+        }
+    }
+
     /// Find the surface_id for a given WlSurface.
     pub fn surface_id_for_wl_surface(&self, wl_surface: &WlSurface) -> Option<u64> {
         self.surface_to_window.iter().find_map(|(id, window)| {
-            window
+            if window
                 .toplevel()
                 .map(|t| *t.wl_surface() == *wl_surface)
                 .unwrap_or(false)
-                .then_some(*id)
+            {
+                return Some(*id);
+            }
+
+            #[cfg(feature = "xwayland")]
+            if window
+                .x11_surface()
+                .and_then(|surface| surface.wl_surface())
+                .map(|surface| surface == *wl_surface)
+                .unwrap_or(false)
+            {
+                return Some(*id);
+            }
+
+            None
         })
     }
 }

--- a/compositor/src/vr/openxr_state.rs
+++ b/compositor/src/vr/openxr_state.rs
@@ -497,6 +497,21 @@ impl VrState {
         self.frame_timing.stats_sexp()
     }
 
+    /// Generate IPC diagnostics for OpenXR-enabled builds.
+    pub fn diagnostics_sexp(&self) -> String {
+        format!(
+            "(:renderer-ready {} :xr-state :{} :swapchain-count {} :view-count {} :frame-wait-count {} :frame-begin-count {} :frame-end-count {} :scene-node-count {} :texture-count 0 :test-pattern nil :last-readback-hash nil :last-frame-error nil :last-end-error nil :drm-lease nil :beyond-hid nil)",
+            if self.renderer.is_some() { "t" } else { "nil" },
+            self.session_state.as_str(),
+            self.swapchains.len(),
+            self.view_config_views.len(),
+            self.frame_timing.wait_times.len(),
+            self.frame_timing.render_times.len(),
+            self.frame_timing.submit_times.len(),
+            self.scene.surface_count(),
+        )
+    }
+
     /// Returns a reference to swapchains for the renderer.
     pub fn swapchains_mut(&mut self) -> &mut Vec<xr::Swapchain<xr::OpenGL>> {
         &mut self.swapchains

--- a/compositor/src/vr/stub.rs
+++ b/compositor/src/vr/stub.rs
@@ -147,6 +147,14 @@ impl VrState {
         "(:fps 0 :missed 0 :frame-time-ms 0.0)".to_string()
     }
 
+    /// Generate IPC diagnostics for builds without OpenXR enabled.
+    pub fn diagnostics_sexp(&self) -> String {
+        format!(
+            "(:renderer-ready nil :xr-state :disabled :swapchain-count 0 :view-count 0 :frame-wait-count 0 :frame-begin-count 0 :frame-end-count 0 :scene-node-count {} :texture-count 0 :test-pattern nil :last-readback-hash nil :last-frame-error nil :last-end-error nil :drm-lease nil :beyond-hid nil)",
+            self.scene.surface_count(),
+        )
+    }
+
     /// Poll for VR events. No-op when VR is disabled.
     pub fn poll_events(&mut self) {}
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -74,9 +74,10 @@ length-prefixed s-expressions.
    parsed in Rust via the `lexpr` crate. Length-prefixed framing avoids
    incremental parsing complexity.
 
-4. **Feature flags**: The `vr` Cargo feature gates OpenXR dependencies.
-   The `full-backend` feature (default) gates DRM/winit. Headless builds
-   disable both.
+4. **Feature flags**: The portable Cargo default builds the headless lane.
+   The `full-backend` feature gates DRM/winit, and the `vr` feature gates
+   OpenXR dependencies. Linux host/session builds opt into `full-backend`
+   explicitly.
 
 5. **No openxrs in data modules**: Modules like `scene.rs`,
    `drm_lease.rs`, `gaze_focus.rs`, `blink_wink.rs`, `gaze_zone.rs`,
@@ -140,16 +141,19 @@ sudo dnf install wayland-devel wayland-protocols-devel \
   libxkbcommon-devel seatd-devel udev-devel \
   openxr-devel monado
 
-# Build compositor
+# Portable headless check/build
 cd compositor
 cargo build
 
-# Build with headless-only (no GPU required)
-cargo build --no-default-features
+# Build Linux host compositor with DRM/winit
+cargo build --features full-backend
 
-# Build with VR support
-cargo build --features vr
+# Build Linux host compositor with VR support
+cargo build --features full-backend,vr
 ```
+
+The `vr` feature follows the OpenXR crate stack and currently needs Rust
+1.88+; the flake dev shell provides a suitable nightly toolchain.
 
 ### Cross-Compilation
 
@@ -800,12 +804,12 @@ emacs --batch -L lisp/core -L lisp/vr -L lisp/ext \
   --eval '(setq ewwm-test-selector "ewwm-bci-core")' \
   -l test/run-tests.el
 
-# Rust unit tests
-cargo test --manifest-path compositor/Cargo.toml
+# Portable Rust test compile check
+cargo check --manifest-path compositor/Cargo.toml --tests
 
-# Headless-only Rust tests (no GPU)
+# Linux full-backend Rust tests
 cargo test --manifest-path compositor/Cargo.toml \
-  --no-default-features
+  --features full-backend
 ```
 
 ### Test File Inventory

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -9,7 +9,7 @@ This document is an inventory, not a support promise. For the current operationa
 ## 1. IPC Command Reference
 
 The dispatcher in `compositor/src/ipc/dispatch.rs` currently contains
-**184 commands** in this checkout. The grouped table below is still being
+**195 commands** in this checkout. The grouped table below is still being
 reconciled and should not be treated as exhaustive until it is regenerated
 from code.
 
@@ -31,6 +31,18 @@ from code.
 | `workspace-move-surface` | state.rs | ewwm-workspace | none |
 | `layout-set` | state.rs | ewwm-layout | none |
 | `layout-cycle` | state.rs | ewwm-layout | none |
+| `app-launch` / `launch-app` | state.rs | ewwm-launch | none |
+| `app-launch-list` | state.rs | ewwm-launch | none |
+| `config-reload` / `reload-config` | state.rs | ewwm-ipc | none |
+| `autostart-list` | state.rs | ewwm-autostart | none |
+| `autostart-run` | state.rs | ewwm-autostart | none |
+| `session-status` | state.rs | ewwm-session | none |
+| `session-lock` | state.rs | ewwm-session | none |
+| `session-logout` | state.rs | ewwm-session | none |
+| `session-idle-status` | state.rs | ewwm-session | none |
+| `session-idle-start` | state.rs | ewwm-session | none |
+| `session-idle-stop` | state.rs | ewwm-session | none |
+| `compositor-exit` | state.rs | ewwm-session | none |
 | `key-grab` | state.rs | ewwm-input | none |
 | `key-ungrab` | state.rs | ewwm-input | none |
 
@@ -39,6 +51,7 @@ from code.
 | Command | Rust module | Elisp module | Hardware |
 |---------|-------------|--------------|----------|
 | `vr-status` | openxr_state.rs / stub.rs | ewwm-vr | HMD |
+| `vr-diagnostics` | openxr_state.rs / stub.rs | ewwm-vr | HMD |
 | `vr-set-reference-space` | openxr_state.rs / stub.rs | ewwm-vr | HMD |
 | `vr-restart` | openxr_state.rs / stub.rs | ewwm-vr | HMD |
 | `vr-get-frame-timing` | frame_timing.rs | ewwm-vr | HMD |

--- a/docs/installation-quickstart.md
+++ b/docs/installation-quickstart.md
@@ -94,7 +94,7 @@ git clone https://github.com/Jesssullivan/XoxdWM.git
 cd XoxdWM
 
 # Build compositor (requires Rust 1.70+, wayland-devel, mesa, libinput, libxkbcommon)
-cargo build --release --manifest-path compositor/Cargo.toml
+cargo build --release --manifest-path compositor/Cargo.toml --features full-backend
 
 # Install
 sudo install -Dm755 compositor/target/release/ewwm-compositor /usr/local/bin/

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -244,6 +244,66 @@ Cycle to next layout algorithm.
 (:type :layout-cycle :id 13)
 ```
 
+Layout is native compositor policy. Emacs/eGreg clients may request
+`:layout-set` or `:layout-cycle`, but connected clients should treat the
+`:layout-changed` event as the app-layer mirror update.
+
+### Native Authority Policy
+
+#### `:app-launch` / `:launch-app`
+
+Launch a configured native app target by name. The IPC command does not accept
+arbitrary shell commands; targets come from native JSON `app_launch.NAME`.
+
+```elisp
+(:type :app-launch :id 14 :target "terminal")
+```
+
+#### `:app-launch-list`
+
+```elisp
+(:type :app-launch-list :id 15)
+```
+
+#### `:config-reload` / `:reload-config`
+
+Reload native compositor config and emit `:config-reloaded`.
+
+```elisp
+(:type :config-reload :id 16)
+```
+
+#### `:autostart-list` / `:autostart-run`
+
+List or run configured native autostart targets. Duplicate targets are skipped
+per compositor session unless `:force t` is supplied.
+
+```elisp
+(:type :autostart-list :id 17)
+(:type :autostart-run :id 18 :force t)
+```
+
+#### `:session-status`, `:session-lock`, `:session-logout`
+
+Native session IPC covers lock and compositor logout only. Shutdown, reboot,
+suspend, and hibernate remain app-layer/operator policy.
+
+```elisp
+(:type :session-status :id 19)
+(:type :session-lock :id 20)
+(:type :session-logout :id 21)
+```
+
+#### `:session-idle-status`, `:session-idle-start`, `:session-idle-stop`
+
+These supervise one configured idle command when native config enables it.
+
+```elisp
+(:type :session-idle-status :id 22)
+(:type :session-idle-start :id 23)
+(:type :session-idle-stop :id 24)
+```
+
 ### Input
 
 #### `:key-grab`
@@ -342,8 +402,12 @@ Events are pushed to all connected clients. No acknowledgment required.
 #### `:surface-focused`
 
 ```elisp
-(:type :event :event :surface-focused :id 2)
+(:type :event :event :surface-focused :id 2 :previous-id 1)
 ```
+
+`:surface-focused` is the canonical focus event.  Legacy runtimes may also
+emit `:focus-changed` with `:old` and `:new`; clients should treat that as a
+temporary compatibility alias.
 
 #### `:surface-geometry-changed`
 

--- a/test/ipc-contract-test.el
+++ b/test/ipc-contract-test.el
@@ -1,0 +1,145 @@
+;;; ipc-contract-test.el --- Static IPC contract checks -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; These tests keep the Rust dispatcher and Lisp IPC clients from drifting
+;; silently while the WM authority boundary moves into native XoxdWM code.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ert)
+
+(defconst ipc-contract-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name)))))
+
+(defconst ipc-contract-test--known-elisp-without-rust-handler
+  '("anchor-create"
+    "anchor-goto"
+    "anchor-list"
+    "anchor-remove"
+    "anchor-restore"
+    "anchor-status"
+    "bci-attention-calibrate"
+    "bci-attention-toggle"
+    "bci-dnd-disable"
+    "bci-dnd-enable"
+    "bci-hardware-check"
+    "bci-mi-calibrate"
+    "bci-mi-toggle"
+    "bci-nfb-start"
+    "bci-nfb-stop"
+    "bci-p300-cancel"
+    "bci-ssvep-configure"
+    "command"
+    "focus-routing-configure"
+    "focus-routing-set-dwell"
+    "focus-routing-set-mode"
+    "focus-routing-status"
+    "focus-surface"
+    "follow-configure"
+    "follow-recenter"
+    "follow-set-policy"
+    "follow-status"
+    "gaze-zone-set-layout"
+    "hand-tracking-configure"
+    "hand-tracking-toggle"
+    "input-latency-probe"
+    "multimodal-disable"
+    "multimodal-enable"
+    "multimodal-set-dwell"
+    "multimodal-three-factor-start"
+    "overlay-create"
+    "overlay-link-surface"
+    "overlay-list"
+    "overlay-remove"
+    "overlay-set-alpha"
+    "overlay-set-visible"
+    "overlay-status"
+    "passkey-response"
+    "passthrough-disable"
+    "passthrough-enable"
+    "passthrough-set-blend-mode"
+    "passthrough-set-opacity"
+    "passthrough-status"
+    "surface-move-interactive"
+    "surface-resize-interactive"
+    "transient-configure"
+    "transient-list"
+    "transient-set-offset"
+    "transient-set-placement"
+    "transient-status")
+  "Current known Lisp request types that do not have Rust dispatch handlers.")
+
+(defconst ipc-contract-test--known-payload-debt
+  '("surface-resize geometry payload"
+    "focus event name/payload"
+    "gaze focus event name")
+  "Known IPC schema debt not represented by command-name parity alone.")
+
+(defun ipc-contract-test--read-file (relative)
+  "Return project file RELATIVE as a string."
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name relative ipc-contract-test--root))
+    (buffer-string)))
+
+(defun ipc-contract-test--rust-dispatch-commands ()
+  "Return top-level Rust IPC dispatch command strings."
+  (let ((content (ipc-contract-test--read-file "compositor/src/ipc/dispatch.rs"))
+        (start nil)
+        (end nil)
+        (commands nil))
+    (setq start (string-match "match msg_type\\.as_deref()" content))
+    (should start)
+    (setq end (string-match "^[[:space:]]*other =>" content start))
+    (should end)
+    (with-temp-buffer
+      (insert (substring content start end))
+      (goto-char (point-min))
+      (while (re-search-forward "Some(\"\\([^\"]+\\)\")" nil t)
+        (push (match-string 1) commands)))
+    (sort (delete-dups commands) #'string<)))
+
+(defun ipc-contract-test--elisp-request-types ()
+  "Return Lisp request `:type' keywords found under lisp/."
+  (let ((commands nil))
+    (dolist (dir '("lisp/core" "lisp/vr" "lisp/ext"))
+      (let ((abs-dir (expand-file-name dir ipc-contract-test--root)))
+        (when (file-directory-p abs-dir)
+          (dolist (file (directory-files-recursively abs-dir "\\.el\\'"))
+            (with-temp-buffer
+              (insert-file-contents file)
+              (goto-char (point-min))
+              (while (re-search-forward ":type[[:space:]\n]+:\\([A-Za-z0-9_-]+\\)" nil t)
+                (unless (string= (match-string 1) "event")
+                  (push (match-string 1) commands))))))))
+    (sort (delete-dups commands) #'string<)))
+
+(ert-deftest ipc-contract/elisp-requests-have-rust-handler-or-known-debt ()
+  "Every Lisp request type should either dispatch in Rust or be listed debt."
+  (let* ((rust (ipc-contract-test--rust-dispatch-commands))
+         (elisp (ipc-contract-test--elisp-request-types))
+         (missing (cl-set-difference elisp rust :test #'string=))
+         (unexpected (cl-set-difference
+                      missing
+                      ipc-contract-test--known-elisp-without-rust-handler
+                      :test #'string=))
+         (retired-debt (cl-set-difference
+                        ipc-contract-test--known-elisp-without-rust-handler
+                        missing
+                        :test #'string=)))
+    (ert-info ((format "unexpected missing Rust handlers: %S" unexpected))
+      (should-not unexpected))
+    (ert-info ((format "known IPC debt no longer observed; update the debt list: %S"
+                       retired-debt))
+      (should-not retired-debt))))
+
+(ert-deftest ipc-contract/known-schema-debt-is-explicit ()
+  "Schema mismatches that command-name parity cannot see should stay explicit."
+  (dolist (item '("surface-resize geometry payload"
+                  "focus event name/payload"
+                  "gaze focus event name"))
+    (should (member item ipc-contract-test--known-payload-debt))))
+
+;;; ipc-contract-test.el ends here

--- a/test/v041-wm-commands-test.el
+++ b/test/v041-wm-commands-test.el
@@ -91,6 +91,15 @@
       (insert-file-contents file)
       (should (search-forward ":count" nil t)))))
 
+(ert-deftest v041/workspace-list-uses-native-workspace-count ()
+  "workspace-list should use native state rather than hard-coded four."
+  (let ((file (expand-file-name "compositor/src/ipc/dispatch.rs" v041-test--root)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (let ((content (buffer-string)))
+        (should (string-match-p "0\\.\\.state\\.workspace_count" content))
+        (should-not (string-match-p "for i in 0\\.\\.4" content))))))
+
 ;; ── Layout (Emacs-driven) ──────────────────────────────────
 
 (ert-deftest v041/layout-set-reads-layout-param ()


### PR DESCRIPTION
Refs #45. Issue set: #51, #54, #55, #59, #64, #65. Stacked on #74.

## Scope
- Moves JSON-backed compositor config into the native startup and command authority path.
- Adds configured workspace/layout/key-action/app-launch/config-reload IPC surfaces.
- Adds IPC contract guardrails and updates protocol/feature inventory for the native authority command surface.

## Validation
- cargo fmt --manifest-path compositor/Cargo.toml --check
- cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features
- just ipc-contract-test
- Verified on final stack tip: just test

Issue closure should happen only after the implementing PR has merged.