### PR TITLE
native-authority: runtime policy

### DIFF
--- a/compositor/src/autotype.rs
+++ b/compositor/src/autotype.rs
@@ -4,7 +4,7 @@
 //! characters, yields one `AutoTypeEvent` per tick, and supports pause/resume
 //! and abort.  Remaining text is zeroed on drop to limit credential exposure.
 
-use tracing::{debug, info, warn, error};
+use tracing::{debug, error, info, warn};
 
 // ── AutoTypeConfig ──────────────────────────────────────────
 
@@ -70,14 +70,9 @@ pub enum AutoTypePhase {
         reason: PauseReason,
     },
     /// Typing completed successfully.
-    Complete {
-        surface_id: u64,
-        chars_typed: usize,
-    },
+    Complete { surface_id: u64, chars_typed: usize },
     /// An error occurred during typing.
-    Error {
-        message: String,
-    },
+    Error { message: String },
 }
 
 // ── AutoTypeEvent ───────────────────────────────────────────
@@ -185,7 +180,10 @@ impl AutoTypeManager {
     /// sequence is already in progress.
     pub fn start_typing(&mut self, text: &str, surface_id: u64) -> Result<(), String> {
         // Reject if already typing
-        if matches!(self.phase, AutoTypePhase::Typing { .. } | AutoTypePhase::Paused { .. }) {
+        if matches!(
+            self.phase,
+            AutoTypePhase::Typing { .. } | AutoTypePhase::Paused { .. }
+        ) {
             let msg = "auto-type sequence already in progress".to_string();
             warn!("{}", msg);
             return Err(msg);
@@ -390,7 +388,10 @@ impl AutoTypeManager {
                 surface_id,
                 chars_typed,
             } => {
-                format!("complete :surface-id {} :chars-typed {}", surface_id, chars_typed)
+                format!(
+                    "complete :surface-id {} :chars-typed {}",
+                    surface_id, chars_typed
+                )
             }
             AutoTypePhase::Error { message } => {
                 format!("error :message \"{}\"", message)
@@ -400,7 +401,11 @@ impl AutoTypeManager {
             "(:phase {} :delay-ms {} :verify-surface {} :max-chars {} :secure {})",
             phase_str,
             self.config.delay_ms,
-            if self.config.verify_surface { "t" } else { "nil" },
+            if self.config.verify_surface {
+                "t"
+            } else {
+                "nil"
+            },
             self.config.max_chars,
             if self.secure_mode { "t" } else { "nil" },
         )
@@ -417,8 +422,7 @@ impl AutoTypeManager {
     /// Zero out any remaining text in memory to limit credential exposure.
     pub fn clear_sensitive(&mut self) {
         match &mut self.phase {
-            AutoTypePhase::Typing { remaining, .. }
-            | AutoTypePhase::Paused { remaining, .. } => {
+            AutoTypePhase::Typing { remaining, .. } | AutoTypePhase::Paused { remaining, .. } => {
                 for ch in remaining.iter_mut() {
                     *ch = '\0';
                 }
@@ -481,7 +485,10 @@ mod tests {
         let evt = mgr.tick();
         assert!(matches!(
             evt,
-            Some(AutoTypeEvent::CharTyped { ch: 'a', surface_id: 1 })
+            Some(AutoTypeEvent::CharTyped {
+                ch: 'a',
+                surface_id: 1
+            })
         ));
 
         // Verify state
@@ -500,7 +507,10 @@ mod tests {
         let evt = mgr.tick();
         assert!(matches!(
             evt,
-            Some(AutoTypeEvent::CharTyped { ch: 'b', surface_id: 1 })
+            Some(AutoTypeEvent::CharTyped {
+                ch: 'b',
+                surface_id: 1
+            })
         ));
     }
 
@@ -514,13 +524,7 @@ mod tests {
 
         // Pause
         mgr.pause(PauseReason::GazeAway);
-        assert!(matches!(
-            mgr.phase,
-            AutoTypePhase::Paused {
-                typed: 1,
-                ..
-            }
-        ));
+        assert!(matches!(mgr.phase, AutoTypePhase::Paused { typed: 1, .. }));
 
         // Tick while paused should return None
         assert!(mgr.tick().is_none());

--- a/compositor/src/backend/drm.rs
+++ b/compositor/src/backend/drm.rs
@@ -15,8 +15,9 @@
 //! scanout, wait for vblank, then call frame_submitted() and render
 //! the next frame.
 
-use crate::{ipc, state::EwwmState};
 use super::IpcConfig;
+use crate::config::CompositorConfig;
+use crate::{ipc, state::EwwmState};
 
 use smithay::{
     backend::{
@@ -26,41 +27,27 @@ use smithay::{
             gbm::{GbmAllocator, GbmBufferFlags, GbmDevice},
             Fourcc,
         },
-        drm::{
-            DrmDevice, DrmDeviceFd, DrmEvent, DrmNode,
-            GbmBufferedSurface, NodeType,
-        },
+        drm::{DrmDevice, DrmDeviceFd, DrmEvent, DrmNode, GbmBufferedSurface, NodeType},
         egl::{EGLContext, EGLDisplay},
         libinput::{LibinputInputBackend, LibinputSessionInterface},
-        renderer::{
-            damage::OutputDamageTracker,
-            gles::GlesRenderer,
-            Bind,
-        },
-        session::{
-            libseat::LibSeatSession,
-            Session, Event as SessionEvent,
-        },
+        renderer::{damage::OutputDamageTracker, gles::GlesRenderer, Bind},
+        session::{libseat::LibSeatSession, Event as SessionEvent, Session},
         udev::{UdevBackend, UdevEvent},
     },
     output::{Mode as OutputMode, Output, PhysicalProperties, Subpixel},
     reexports::{
-        calloop::{
-            EventLoop, LoopHandle, RegistrationToken,
-        },
-        drm::control::{
-            connector, crtc, Device as ControlDevice, ModeTypeFlags,
-        },
+        calloop::{EventLoop, LoopHandle, RegistrationToken},
+        drm::control::{connector, crtc, Device as ControlDevice, ModeTypeFlags},
         input::Libinput,
         wayland_server::Display,
     },
     utils::{DeviceFd, Size, Transform},
-    xwayland::{XWayland, XWaylandEvent},
     xwayland::xwm::X11Wm,
+    xwayland::{XWayland, XWaylandEvent},
 };
 
-use std::collections::{HashMap, HashSet};
 use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::rc::Rc;
@@ -194,14 +181,16 @@ fn device_added(
     info!(?path, ?node, "opening DRM device");
 
     // Open the device through the session (for seatd privilege).
-    let fd = backend.session.open(
-        path,
-        smithay::reexports::rustix::fs::OFlags::RDWR
-            | smithay::reexports::rustix::fs::OFlags::CLOEXEC
-            | smithay::reexports::rustix::fs::OFlags::NOCTTY
-            | smithay::reexports::rustix::fs::OFlags::NONBLOCK,
-    )
-    .map_err(|e| anyhow::anyhow!("failed to open DRM device {:?}: {}", path, e))?;
+    let fd = backend
+        .session
+        .open(
+            path,
+            smithay::reexports::rustix::fs::OFlags::RDWR
+                | smithay::reexports::rustix::fs::OFlags::CLOEXEC
+                | smithay::reexports::rustix::fs::OFlags::NOCTTY
+                | smithay::reexports::rustix::fs::OFlags::NONBLOCK,
+        )
+        .map_err(|e| anyhow::anyhow!("failed to open DRM device {:?}: {}", path, e))?;
 
     let drm_fd = DrmDeviceFd::new(DeviceFd::from(fd));
 
@@ -225,24 +214,22 @@ fn device_added(
         .map_err(|e| anyhow::anyhow!("GlesRenderer::new failed: {}", e))?;
 
     // Get renderer's supported DMA-BUF render formats for surface creation.
-    let renderer_formats = renderer
-        .egl_context()
-        .dmabuf_render_formats()
-        .clone();
+    let renderer_formats = renderer.egl_context().dmabuf_render_formats().clone();
 
     // Register DRM event source with calloop for vblank notifications.
     let drm_node = node;
     let drm_token = loop_handle
-        .insert_source(drm_notifier, move |event, _metadata, state: &mut EwwmState| {
-            match event {
+        .insert_source(
+            drm_notifier,
+            move |event, _metadata, state: &mut EwwmState| match event {
                 DrmEvent::VBlank(crtc) => {
                     handle_vblank(state, drm_node, crtc);
                 }
                 DrmEvent::Error(err) => {
                     error!(?err, "DRM device error");
                 }
-            }
-        })
+            },
+        )
         .map_err(|e| anyhow::anyhow!("failed to register DRM source: {}", e))?;
 
     let mut gpu = GpuDevice {
@@ -328,11 +315,7 @@ fn lease_connector_overrides() -> HashSet<String> {
 }
 
 /// Scan DRM connectors and set up outputs for each connected display.
-fn scan_connectors(
-    gpu: &mut GpuDevice,
-    renderer_formats: &FormatSet,
-    state: &mut EwwmState,
-) {
+fn scan_connectors(gpu: &mut GpuDevice, renderer_formats: &FormatSet, state: &mut EwwmState) {
     let res = match gpu.drm.borrow().resource_handles() {
         Ok(r) => r,
         Err(e) => {
@@ -393,29 +376,25 @@ fn scan_connectors(
     let mut vr_connectors = Vec::new();
     for connector in &connectors {
         let connector_type = match connector.info.interface() {
-                connector::Interface::DisplayPort => {
-                    crate::vr::drm_lease::ConnectorType::DisplayPort
-                }
-                connector::Interface::HDMIA | connector::Interface::HDMIB => {
-                    crate::vr::drm_lease::ConnectorType::Hdmi
-                }
-                connector::Interface::USB => crate::vr::drm_lease::ConnectorType::UsbC,
-                connector::Interface::Virtual => {
-                    crate::vr::drm_lease::ConnectorType::Virtual
-                }
-                _ => crate::vr::drm_lease::ConnectorType::Unknown,
-            };
+            connector::Interface::DisplayPort => crate::vr::drm_lease::ConnectorType::DisplayPort,
+            connector::Interface::HDMIA | connector::Interface::HDMIB => {
+                crate::vr::drm_lease::ConnectorType::Hdmi
+            }
+            connector::Interface::USB => crate::vr::drm_lease::ConnectorType::UsbC,
+            connector::Interface::Virtual => crate::vr::drm_lease::ConnectorType::Virtual,
+            _ => crate::vr::drm_lease::ConnectorType::Unknown,
+        };
         let modes: Vec<crate::vr::drm_lease::DisplayMode> = connector
             .info
             .modes()
-                .iter()
-                .map(|m| crate::vr::drm_lease::DisplayMode {
-                    width: m.size().0 as u32,
-                    height: m.size().1 as u32,
-                    refresh_hz: (m.vrefresh() as u32).max(1),
-                    preferred: m.mode_type().contains(ModeTypeFlags::PREFERRED),
-                })
-                .collect();
+            .iter()
+            .map(|m| crate::vr::drm_lease::DisplayMode {
+                width: m.size().0 as u32,
+                height: m.size().1 as u32,
+                refresh_hz: (m.vrefresh() as u32).max(1),
+                preferred: m.mode_type().contains(ModeTypeFlags::PREFERRED),
+            })
+            .collect();
 
         vr_connectors.push(crate::vr::drm_lease::DrmConnectorInfo {
             connector_id: connector.info.handle().into(),
@@ -595,6 +574,17 @@ fn scan_connectors(
         );
         output.set_preferred(wl_mode);
         state.space.map_output(&output, (x_offset, 0));
+        let mut output_config =
+            crate::handlers::output_management::OutputConfig::new(connector_name.clone());
+        output_config.enabled = true;
+        output_config.x = x_offset;
+        output_config.y = 0;
+        output_config.width = drm_mode.size().0 as i32;
+        output_config.height = drm_mode.size().1 as i32;
+        output_config.refresh = (drm_mode.vrefresh() * 1000) as i32;
+        state
+            .output_management_state
+            .upsert_detected_output(output_config);
 
         info!(
             name = %connector_name,
@@ -655,6 +645,10 @@ fn device_removed(
 
         // Unmap all outputs from the space.
         for (_crtc, output_state) in &gpu.outputs {
+            let output_name = output_state.output.name();
+            state
+                .output_management_state
+                .remove_detected_output(&output_name);
             state.space.unmap_output(&output_state.output);
         }
 
@@ -680,11 +674,7 @@ fn device_removed(
 // ---------------------------------------------------------------------------
 
 /// Render a frame for the specified output and queue it for scanout.
-fn render_output(
-    gpu: &mut GpuDevice,
-    crtc: crtc::Handle,
-    state: &mut EwwmState,
-) {
+fn render_output(gpu: &mut GpuDevice, crtc: crtc::Handle, state: &mut EwwmState) {
     let output_state = match gpu.outputs.get_mut(&crtc) {
         Some(s) => s,
         None => return,
@@ -752,11 +742,7 @@ fn render_output(
 /// Since the calloop callback only receives `&mut EwwmState` (not the
 /// DRM backend data), we record the vblank in thread-local storage for
 /// the main loop to process via [`process_vblanks`].
-fn handle_vblank(
-    _state: &mut EwwmState,
-    node: DrmNode,
-    crtc: crtc::Handle,
-) {
+fn handle_vblank(_state: &mut EwwmState, node: DrmNode, crtc: crtc::Handle) {
     debug!(?node, ?crtc, "vblank received");
     record_vblank(node, crtc);
 }
@@ -852,14 +838,19 @@ fn session_activated(backend: &mut DrmBackendData, state: &mut EwwmState) {
 ///
 /// This function blocks until the compositor shuts down (signal, IPC
 /// command, or session loss). It returns `Ok(())` on clean shutdown.
-pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result<()> {
+pub fn run(
+    socket_name: Option<String>,
+    ipc_config: IpcConfig,
+    compositor_config: CompositorConfig,
+) -> anyhow::Result<()> {
     info!("DRM backend starting");
 
     // ── 1. Create calloop event loop and Wayland display ──────────────
 
     let mut event_loop = EventLoop::<EwwmState>::try_new()?;
     let mut display = Display::<EwwmState>::new()?;
-    let mut state = EwwmState::new(&mut display, event_loop.handle());
+    let mut state =
+        EwwmState::new_with_config(&mut display, event_loop.handle(), compositor_config);
 
     // ── 2. Configure IPC ──────────────────────────────────────────────
 
@@ -872,12 +863,13 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
 
     // ── 3. Initialize libseat session ─────────────────────────────────
 
-    let (session, session_notifier) = LibSeatSession::new()
-        .map_err(|e| anyhow::anyhow!(
+    let (session, session_notifier) = LibSeatSession::new().map_err(|e| {
+        anyhow::anyhow!(
             "failed to initialize libseat session: {}. \
              Is seatd/logind running? Try: export LIBSEAT_BACKEND=builtin",
             e
-        ))?;
+        )
+    })?;
 
     let seat_name = session.seat();
     info!(seat = %seat_name, "libseat session initialized");
@@ -926,7 +918,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
 
     info!(
         device_count = backend_data.devices.len(),
-        output_count = backend_data.devices.values()
+        output_count = backend_data
+            .devices
+            .values()
             .map(|g| g.outputs.len())
             .sum::<usize>(),
         "DRM devices initialized"
@@ -959,10 +953,8 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
                         // which is &*const c_void. Deref twice to get the raw ptr.
                         let raw_display: *mut std::ffi::c_void =
                             **display_handle as *mut std::ffi::c_void;
-                        let raw_config = egl_ctx.config_id()
-                            as *mut std::ffi::c_void;
-                        let raw_context = egl_ctx.get_context_handle()
-                            as *mut std::ffi::c_void;
+                        let raw_config = egl_ctx.config_id() as *mut std::ffi::c_void;
+                        let raw_context = egl_ctx.get_context_handle() as *mut std::ffi::c_void;
                         if let Err(e) = state.vr_state.create_session(
                             raw_display as *mut std::ffi::c_void,
                             raw_config,
@@ -984,10 +976,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
 
     // ── 5. Set up libinput for input events ───────────────────────────
 
-    let mut libinput_context =
-        Libinput::new_with_udev::<LibinputSessionInterface<LibSeatSession>>(
-            backend_data.session.clone().into(),
-        );
+    let mut libinput_context = Libinput::new_with_udev::<LibinputSessionInterface<LibSeatSession>>(
+        backend_data.session.clone().into(),
+    );
 
     if let Err(e) = libinput_context.udev_assign_seat(&seat_name) {
         return Err(anyhow::anyhow!(
@@ -1041,8 +1032,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
 
     event_loop
         .handle()
-        .insert_source(udev_backend, move |event, _, _state: &mut EwwmState| {
-            match event {
+        .insert_source(
+            udev_backend,
+            move |event, _, _state: &mut EwwmState| match event {
                 UdevEvent::Added { device_id, path } => {
                     info!(device_id, ?path, "udev: device added");
                     UDEV_EVENTS.with(|v| {
@@ -1061,8 +1053,8 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
                         v.borrow_mut().push(UdevAction::Removed { device_id });
                     });
                 }
-            }
-        })
+            },
+        )
         .map_err(|e| anyhow::anyhow!("failed to register udev source: {}", e))?;
 
     // ── 8. Set up Wayland socket ──────────────────────────────────────
@@ -1076,32 +1068,36 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
     wayland_listener.set_nonblocking(true)?;
     info!("Wayland socket: {}", socket_path);
     std::env::set_var("WAYLAND_DISPLAY", &socket_name_str);
+    state.apply_real_session_startup_policy();
 
     // Accept Wayland client connections
-    event_loop.handle().insert_source(
-        smithay::reexports::calloop::generic::Generic::new(
-            wayland_listener,
-            smithay::reexports::calloop::Interest::READ,
-            smithay::reexports::calloop::Mode::Level,
-        ),
-        |_, source, state: &mut EwwmState| {
-            match source.accept() {
-                Ok((stream, _)) => {
-                    if let Err(e) = state.display_handle.insert_client(
-                        stream,
-                        std::sync::Arc::new(crate::state::ClientState::default()),
-                    ) {
-                        warn!("failed to insert Wayland client: {}", e);
+    event_loop
+        .handle()
+        .insert_source(
+            smithay::reexports::calloop::generic::Generic::new(
+                wayland_listener,
+                smithay::reexports::calloop::Interest::READ,
+                smithay::reexports::calloop::Mode::Level,
+            ),
+            |_, source, state: &mut EwwmState| {
+                match source.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(e) = state.display_handle.insert_client(
+                            stream,
+                            std::sync::Arc::new(crate::state::ClientState::default()),
+                        ) {
+                            warn!("failed to insert Wayland client: {}", e);
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(e) => {
+                        warn!("Wayland socket accept error: {}", e);
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(e) => {
-                    warn!("Wayland socket accept error: {}", e);
-                }
-            }
-            Ok(smithay::reexports::calloop::PostAction::Continue)
-        },
-    ).map_err(|e| anyhow::anyhow!("failed to insert socket source: {:?}", e))?;
+                Ok(smithay::reexports::calloop::PostAction::Continue)
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("failed to insert socket source: {:?}", e))?;
 
     // ── 9. Spawn XWayland ─────────────────────────────────────────────
 
@@ -1117,8 +1113,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
         Ok((xwayland, client)) => {
             event_loop
                 .handle()
-                .insert_source(xwayland, move |event, _, state: &mut EwwmState| {
-                    match event {
+                .insert_source(
+                    xwayland,
+                    move |event, _, state: &mut EwwmState| match event {
                         XWaylandEvent::Ready {
                             x11_socket,
                             display_number,
@@ -1132,10 +1129,7 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
                                 Ok(wm) => {
                                     state.xwm = Some(wm);
                                     state.xdisplay = Some(display_number);
-                                    std::env::set_var(
-                                        "DISPLAY",
-                                        format!(":{}", display_number),
-                                    );
+                                    std::env::set_var("DISPLAY", format!(":{}", display_number));
                                 }
                                 Err(e) => {
                                     error!("failed to start X11 WM: {}", e);
@@ -1148,8 +1142,8 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
                                  (continuing without X11 support)"
                             );
                         }
-                    }
-                })
+                    },
+                )
                 .ok();
             info!("XWayland spawning");
         }
@@ -1224,10 +1218,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
 
                     // Render scene content into swapchain images (or
                     // fall back to black frames if renderer not ready).
-                    state.vr_state.render_vr_frame(
-                        &frame_data.views,
-                        &view_configs,
-                    );
+                    state
+                        .vr_state
+                        .render_vr_frame(&frame_data.views, &view_configs);
 
                     // Build projection layers and submit frame.
                     let swapchain_count = state.vr_state.swapchain_images().len();
@@ -1261,6 +1254,10 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
     // Unmap all outputs.
     for (_node, gpu) in backend_data.devices.iter_mut() {
         for (_crtc, output_state) in gpu.outputs.iter() {
+            let output_name = output_state.output.name();
+            state
+                .output_management_state
+                .remove_detected_output(&output_name);
             state.space.unmap_output(&output_state.output);
         }
     }
@@ -1311,28 +1308,23 @@ fn process_udev_events(
     state: &mut EwwmState,
     loop_handle: &LoopHandle<'static, EwwmState>,
 ) {
-    let events: Vec<UdevAction> =
-        UDEV_EVENTS.with(|v| std::mem::take(&mut *v.borrow_mut()));
+    let events: Vec<UdevAction> = UDEV_EVENTS.with(|v| std::mem::take(&mut *v.borrow_mut()));
 
     for action in events {
         match action {
-            UdevAction::Added { device_id, path } => {
-                match DrmNode::from_dev_id(device_id) {
-                    Ok(node) => {
-                        if let Err(e) =
-                            device_added(node, &path, backend, state, loop_handle)
-                        {
-                            warn!(
-                                device_id = device_id,
-                                "hotplug: failed to add device: {}", e
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        debug!(device_id, "hotplug: not a DRM device: {}", e);
+            UdevAction::Added { device_id, path } => match DrmNode::from_dev_id(device_id) {
+                Ok(node) => {
+                    if let Err(e) = device_added(node, &path, backend, state, loop_handle) {
+                        warn!(
+                            device_id = device_id,
+                            "hotplug: failed to add device: {}", e
+                        );
                     }
                 }
-            }
+                Err(e) => {
+                    debug!(device_id, "hotplug: not a DRM device: {}", e);
+                }
+            },
             UdevAction::Changed { device_id } => {
                 // Connector hotplug (display plugged/unplugged).
                 if let Ok(node) = DrmNode::from_dev_id(device_id) {
@@ -1346,6 +1338,10 @@ fn process_udev_events(
 
                         // Unmap existing outputs.
                         for (_crtc, output_state) in gpu.outputs.drain() {
+                            let output_name = output_state.output.name();
+                            state
+                                .output_management_state
+                                .remove_detected_output(&output_name);
                             state.space.unmap_output(&output_state.output);
                         }
 
@@ -1355,8 +1351,7 @@ fn process_udev_events(
                         scan_connectors(gpu, &renderer_formats, state);
 
                         // Render initial frames on new outputs.
-                        let crtcs: Vec<crtc::Handle> =
-                            gpu.outputs.keys().copied().collect();
+                        let crtcs: Vec<crtc::Handle> = gpu.outputs.keys().copied().collect();
                         for crtc in crtcs {
                             render_output(gpu, crtc, state);
                         }

--- a/compositor/src/backend/mod.rs
+++ b/compositor/src/backend/mod.rs
@@ -42,9 +42,9 @@ pub fn run(
     };
     match backend {
         #[cfg(feature = "full-backend")]
-        BackendType::Winit => winit::run(socket_name, ipc),
+        BackendType::Winit => winit::run(socket_name, ipc, compositor_config),
         #[cfg(feature = "full-backend")]
-        BackendType::Drm => drm::run(socket_name, ipc),
+        BackendType::Drm => drm::run(socket_name, ipc, compositor_config),
         BackendType::Headless => headless::run(
             socket_name,
             headless_exit_after,

--- a/compositor/src/backend/winit.rs
+++ b/compositor/src/backend/winit.rs
@@ -1,7 +1,8 @@
 //! Winit backend — development mode, compositor runs inside a window.
 
-use crate::{ipc, render, state::EwwmState};
 use super::IpcConfig;
+use crate::config::CompositorConfig;
+use crate::{ipc, render, state::EwwmState};
 use smithay::{
     backend::{
         renderer::damage::OutputDamageTracker,
@@ -14,18 +15,23 @@ use smithay::{
     },
     reexports::wayland_server::Display,
     utils::Transform,
-    xwayland::{XWayland, XWaylandEvent},
     xwayland::xwm::X11Wm,
+    xwayland::{XWayland, XWaylandEvent},
 };
 use std::process::Stdio;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
-pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result<()> {
+pub fn run(
+    socket_name: Option<String>,
+    ipc_config: IpcConfig,
+    compositor_config: CompositorConfig,
+) -> anyhow::Result<()> {
     let mut event_loop = EventLoop::<EwwmState>::try_new()?;
     let mut display = Display::<EwwmState>::new()?;
 
-    let mut state = EwwmState::new(&mut display, event_loop.handle());
+    let mut state =
+        EwwmState::new_with_config(&mut display, event_loop.handle(), compositor_config);
 
     // Configure IPC
     state.ipc_server.ipc_trace = ipc_config.trace;
@@ -36,9 +42,9 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
     ipc::IpcServer::bind(&ipc_path, &event_loop.handle())?;
 
     // Initialize Winit backend
-    let (mut backend, mut winit_evt) = winit_backend::init::<
-        smithay::backend::renderer::gles::GlesRenderer,
-    >().map_err(|e| anyhow::anyhow!("winit init failed: {:?}", e))?;
+    let (mut backend, mut winit_evt) =
+        winit_backend::init::<smithay::backend::renderer::gles::GlesRenderer>()
+            .map_err(|e| anyhow::anyhow!("winit init failed: {:?}", e))?;
 
     // Create output matching window size
     let mode = OutputMode {
@@ -54,9 +60,22 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
             model: "Winit".into(),
         },
     );
-    output.change_current_state(Some(mode), Some(Transform::Normal), None, Some((0, 0).into()));
+    output.change_current_state(
+        Some(mode),
+        Some(Transform::Normal),
+        None,
+        Some((0, 0).into()),
+    );
     output.set_preferred(mode);
     state.space.map_output(&output, (0, 0));
+    let mut output_config =
+        crate::handlers::output_management::OutputConfig::new("winit-0".to_string());
+    output_config.width = 1920;
+    output_config.height = 1080;
+    output_config.refresh = 60_000;
+    state
+        .output_management_state
+        .upsert_detected_output(output_config);
 
     // Set up Wayland socket
     let xdg_runtime_dir = std::env::var("XDG_RUNTIME_DIR")
@@ -68,32 +87,36 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
     listener.set_nonblocking(true)?;
     info!("Wayland socket: {}", socket_path);
     std::env::set_var("WAYLAND_DISPLAY", &socket_name_str);
+    state.apply_real_session_startup_policy();
 
     // Accept Wayland client connections
-    event_loop.handle().insert_source(
-        smithay::reexports::calloop::generic::Generic::new(
-            listener,
-            smithay::reexports::calloop::Interest::READ,
-            smithay::reexports::calloop::Mode::Level,
-        ),
-        |_, source, state: &mut EwwmState| {
-            match source.accept() {
-                Ok((stream, _)) => {
-                    if let Err(e) = state.display_handle.insert_client(
-                        stream,
-                        std::sync::Arc::new(crate::state::ClientState::default()),
-                    ) {
-                        warn!("failed to insert Wayland client: {}", e);
+    event_loop
+        .handle()
+        .insert_source(
+            smithay::reexports::calloop::generic::Generic::new(
+                listener,
+                smithay::reexports::calloop::Interest::READ,
+                smithay::reexports::calloop::Mode::Level,
+            ),
+            |_, source, state: &mut EwwmState| {
+                match source.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(e) = state.display_handle.insert_client(
+                            stream,
+                            std::sync::Arc::new(crate::state::ClientState::default()),
+                        ) {
+                            warn!("failed to insert Wayland client: {}", e);
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                    Err(e) => {
+                        warn!("Wayland socket accept error: {}", e);
                     }
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
-                Err(e) => {
-                    warn!("Wayland socket accept error: {}", e);
-                }
-            }
-            Ok(smithay::reexports::calloop::PostAction::Continue)
-        },
-    ).map_err(|e| anyhow::anyhow!("failed to insert socket source: {:?}", e))?;
+                Ok(smithay::reexports::calloop::PostAction::Continue)
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("failed to insert socket source: {:?}", e))?;
 
     // Spawn XWayland
     match XWayland::spawn(
@@ -106,34 +129,44 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
         |_| (),
     ) {
         Ok((xwayland, client)) => {
-            event_loop.handle().insert_source(xwayland, move |event, _, state: &mut EwwmState| {
-                match event {
-                    XWaylandEvent::Ready { x11_socket, display_number } => {
-                        info!(display_number, "XWayland ready");
-                        match X11Wm::start_wm(
-                            state.loop_handle.clone(),
+            event_loop
+                .handle()
+                .insert_source(
+                    xwayland,
+                    move |event, _, state: &mut EwwmState| match event {
+                        XWaylandEvent::Ready {
                             x11_socket,
-                            client.clone(),
-                        ) {
-                            Ok(wm) => {
-                                state.xwm = Some(wm);
-                                state.xdisplay = Some(display_number);
-                                std::env::set_var("DISPLAY", format!(":{}", display_number));
-                            }
-                            Err(e) => {
-                                error!("Failed to start X11 WM: {}", e);
+                            display_number,
+                        } => {
+                            info!(display_number, "XWayland ready");
+                            match X11Wm::start_wm(
+                                state.loop_handle.clone(),
+                                x11_socket,
+                                client.clone(),
+                            ) {
+                                Ok(wm) => {
+                                    state.xwm = Some(wm);
+                                    state.xdisplay = Some(display_number);
+                                    std::env::set_var("DISPLAY", format!(":{}", display_number));
+                                }
+                                Err(e) => {
+                                    error!("Failed to start X11 WM: {}", e);
+                                }
                             }
                         }
-                    }
-                    XWaylandEvent::Error => {
-                        warn!("XWayland crashed on startup (continuing without X11 support)");
-                    }
-                }
-            }).ok();
+                        XWaylandEvent::Error => {
+                            warn!("XWayland crashed on startup (continuing without X11 support)");
+                        }
+                    },
+                )
+                .ok();
             info!("XWayland spawning");
         }
         Err(e) => {
-            warn!("XWayland not available: {} (continuing without X11 support)", e);
+            warn!(
+                "XWayland not available: {} (continuing without X11 support)",
+                e
+            );
         }
     }
 
@@ -151,19 +184,17 @@ pub fn run(socket_name: Option<String>, ipc_config: IpcConfig) -> anyhow::Result
     let render_output = output.clone();
 
     // Render timer (60 Hz)
-    event_loop.handle().insert_source(
-        Timer::from_duration(Duration::from_millis(16)),
-        move |_, _, state| {
-            // Render frame with damage tracking
-            render::render_winit(
-                &mut backend,
-                &mut damage_tracker,
-                state,
-                &render_output,
-            );
-            TimeoutAction::ToDuration(Duration::from_millis(16))
-        },
-    ).map_err(|e| anyhow::anyhow!("failed to insert render timer: {:?}", e))?;
+    event_loop
+        .handle()
+        .insert_source(
+            Timer::from_duration(Duration::from_millis(16)),
+            move |_, _, state| {
+                // Render frame with damage tracking
+                render::render_winit(&mut backend, &mut damage_tracker, state, &render_output);
+                TimeoutAction::ToDuration(Duration::from_millis(16))
+            },
+        )
+        .map_err(|e| anyhow::anyhow!("failed to insert render timer: {:?}", e))?;
 
     info!("Winit backend initialized, entering event loop");
 

--- a/compositor/src/handlers/compositor.rs
+++ b/compositor/src/handlers/compositor.rs
@@ -2,6 +2,8 @@
 
 use crate::ipc::{dispatch::format_event, server::IpcServer};
 use crate::state::{ClientState, EwwmState};
+#[cfg(feature = "xwayland")]
+use smithay::xwayland::XWaylandClientData;
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
     delegate_compositor,
@@ -22,7 +24,16 @@ impl CompositorHandler for EwwmState {
     }
 
     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
-        &client.get_data::<ClientState>().unwrap().compositor_state
+        if let Some(state) = client.get_data::<ClientState>() {
+            return &state.compositor_state;
+        }
+
+        #[cfg(feature = "xwayland")]
+        if let Some(state) = client.get_data::<XWaylandClientData>() {
+            return &state.compositor_state;
+        }
+
+        panic!("Wayland client is missing compositor state")
     }
 
     fn commit(&mut self, surface: &WlSurface) {
@@ -53,19 +64,16 @@ impl EwwmState {
         };
 
         // Read current app_id and title from xdg toplevel data.
-        let (app_id, title) = smithay::wayland::compositor::with_states(
-            wl_surface,
-            |states| {
-                states
-                    .data_map
-                    .get::<XdgToplevelSurfaceData>()
-                    .map(|data| {
-                        let guard = data.lock().unwrap();
-                        (guard.app_id.clone(), guard.title.clone())
-                    })
-                    .unwrap_or((None, None))
-            },
-        );
+        let (app_id, title) = smithay::wayland::compositor::with_states(wl_surface, |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .map(|data| {
+                    let guard = data.lock().unwrap();
+                    (guard.app_id.clone(), guard.title.clone())
+                })
+                .unwrap_or((None, None))
+        });
 
         let data = match self.surfaces.get_mut(&surface_id) {
             Some(d) => d,
@@ -85,13 +93,14 @@ impl EwwmState {
         }
 
         if changed {
-            let aid = app_id
-                .as_deref()
-                .unwrap_or("");
-            let ttl = title
-                .as_deref()
-                .unwrap_or("");
-            trace!(surface_id, app_id = aid, title = ttl, "surface metadata updated");
+            let aid = app_id.as_deref().unwrap_or("");
+            let ttl = title.as_deref().unwrap_or("");
+            trace!(
+                surface_id,
+                app_id = aid,
+                title = ttl,
+                "surface metadata updated"
+            );
 
             let event = format_event(
                 "surface-updated",

--- a/compositor/src/handlers/dpms.rs
+++ b/compositor/src/handlers/dpms.rs
@@ -52,7 +52,12 @@ mod tests {
 
     #[test]
     fn dpms_state_roundtrip() {
-        for state in [DpmsState::On, DpmsState::Standby, DpmsState::Suspend, DpmsState::Off] {
+        for state in [
+            DpmsState::On,
+            DpmsState::Standby,
+            DpmsState::Suspend,
+            DpmsState::Off,
+        ] {
             let s = state.to_string();
             assert_eq!(DpmsState::from_str_ipc(&s), Some(state));
         }

--- a/compositor/src/handlers/layer_shell.rs
+++ b/compositor/src/handlers/layer_shell.rs
@@ -8,15 +8,12 @@ use crate::ipc::{dispatch::format_event, server::IpcServer};
 use crate::state::EwwmState;
 use smithay::{
     delegate_layer_shell,
-    desktop::{
-        layer_map_for_output,
-        LayerSurface,
-    },
+    desktop::{layer_map_for_output, LayerSurface},
     output::Output,
     reexports::wayland_server::protocol::wl_output::WlOutput,
     wayland::shell::wlr_layer::{
-        ExclusiveZone, Layer, WlrLayerShellHandler, WlrLayerShellState,
-        LayerSurface as WlrLayerSurface,
+        ExclusiveZone, Layer, LayerSurface as WlrLayerSurface, WlrLayerShellHandler,
+        WlrLayerShellState,
     },
 };
 use tracing::{debug, info, warn};

--- a/compositor/src/handlers/mod.rs
+++ b/compositor/src/handlers/mod.rs
@@ -9,12 +9,12 @@ pub mod drm_lease;
 pub mod foreign_toplevel;
 pub mod idle;
 pub mod layer_shell;
-pub mod seat;
-pub mod session_lock;
-pub mod shm;
 pub mod output_management;
 pub mod pointer_constraints;
 pub mod screencopy;
+pub mod seat;
+pub mod session_lock;
+pub mod shm;
 pub mod xdg_activation;
 pub mod xdg_shell;
 #[cfg(feature = "xwayland")]

--- a/compositor/src/handlers/pointer_constraints.rs
+++ b/compositor/src/handlers/pointer_constraints.rs
@@ -9,9 +9,7 @@ use smithay::{
     delegate_pointer_constraints,
     input::pointer::PointerHandle,
     reexports::wayland_server::protocol::wl_surface::WlSurface,
-    wayland::pointer_constraints::{
-        with_pointer_constraint, PointerConstraintsHandler,
-    },
+    wayland::pointer_constraints::{with_pointer_constraint, PointerConstraintsHandler},
 };
 use tracing::{debug, info};
 

--- a/compositor/src/handlers/seat.rs
+++ b/compositor/src/handlers/seat.rs
@@ -3,12 +3,9 @@
 use crate::ipc::{dispatch::format_event, server::IpcServer};
 use crate::state::{CursorImageStatus, EwwmState};
 use smithay::{
-    delegate_cursor_shape, delegate_data_device, delegate_output,
-    delegate_primary_selection, delegate_seat,
-    input::{
-        pointer::CursorImageStatus as SmithayCursorImageStatus,
-        Seat, SeatHandler, SeatState,
-    },
+    delegate_cursor_shape, delegate_data_device, delegate_output, delegate_primary_selection,
+    delegate_seat,
+    input::{pointer::CursorImageStatus as SmithayCursorImageStatus, Seat, SeatHandler, SeatState},
     reexports::wayland_server::protocol::wl_surface::WlSurface,
     wayland::selection::{
         data_device::{
@@ -28,11 +25,7 @@ impl SeatHandler for EwwmState {
         &mut self.seat_state
     }
 
-    fn cursor_image(
-        &mut self,
-        _seat: &Seat<Self>,
-        image: SmithayCursorImageStatus,
-    ) {
+    fn cursor_image(&mut self, _seat: &Seat<Self>, image: SmithayCursorImageStatus) {
         let new_status = match image {
             SmithayCursorImageStatus::Hidden => CursorImageStatus::Hidden,
             SmithayCursorImageStatus::Named(_) => CursorImageStatus::Default,
@@ -44,11 +37,7 @@ impl SeatHandler for EwwmState {
         }
     }
 
-    fn focus_changed(
-        &mut self,
-        _seat: &Seat<Self>,
-        focused: Option<&WlSurface>,
-    ) {
+    fn focus_changed(&mut self, _seat: &Seat<Self>, focused: Option<&WlSurface>) {
         let new_focus = focused.and_then(|wl| self.surface_id_for_wl_surface(wl));
 
         if new_focus != self.focused_surface {
@@ -57,7 +46,7 @@ impl SeatHandler for EwwmState {
 
             debug!(old = ?old, new = ?new_focus, "focus changed");
 
-            // Broadcast focus-changed event to Emacs
+            // Canonical event consumed by Lisp/eGreg clients.
             let old_str = old
                 .map(|id| id.to_string())
                 .unwrap_or_else(|| "nil".to_string());
@@ -66,9 +55,13 @@ impl SeatHandler for EwwmState {
                 .unwrap_or_else(|| "nil".to_string());
 
             let event = format_event(
-                "focus-changed",
-                &[("old", &old_str), ("new", &new_str)],
+                "surface-focused",
+                &[("id", &new_str), ("previous-id", &old_str)],
             );
+            IpcServer::broadcast_event(self, &event);
+
+            // Compatibility alias for older clients and tests.
+            let event = format_event("focus-changed", &[("old", &old_str), ("new", &new_str)]);
             IpcServer::broadcast_event(self, &event);
         }
     }

--- a/compositor/src/handlers/xdg_activation.rs
+++ b/compositor/src/handlers/xdg_activation.rs
@@ -33,10 +33,7 @@ impl XdgActivationHandler for EwwmState {
 
         if let Some(sid) = surface_id {
             // Notify Emacs so it can decide whether to grant focus
-            let event = format_event(
-                "activation-requested",
-                &[("id", &sid.to_string())],
-            );
+            let event = format_event("activation-requested", &[("id", &sid.to_string())]);
             IpcServer::broadcast_event(self, &event);
         }
     }

--- a/compositor/src/handlers/xdg_shell.rs
+++ b/compositor/src/handlers/xdg_shell.rs
@@ -12,8 +12,11 @@ use smithay::{
         pointer::{Focus, GrabStartData as PointerGrabStartData},
         Seat,
     },
-    reexports::wayland_server::protocol::wl_seat::WlSeat,
-    utils::Serial,
+    reexports::{
+        wayland_protocols::xdg::shell::server::xdg_toplevel,
+        wayland_server::protocol::wl_seat::WlSeat,
+    },
+    utils::{Serial, Size},
     wayland::shell::xdg::{
         PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState,
         XdgToplevelSurfaceData,
@@ -30,12 +33,26 @@ impl XdgShellHandler for EwwmState {
         let surface_id = next_surface_id();
         info!(surface_id, "new toplevel surface");
 
+        let initial_geometry = self.initial_window_geometry();
+        surface.with_pending_state(|state| {
+            state.size = Some(Size::from((
+                initial_geometry.size.w,
+                initial_geometry.size.h,
+            )));
+            state.states.set(xdg_toplevel::State::Activated);
+        });
+
         let window = Window::new_wayland_window(surface.clone());
-        self.space.map_element(window.clone(), (0, 0), false);
+        self.space.map_element(
+            window.clone(),
+            (initial_geometry.loc.x, initial_geometry.loc.y),
+            true,
+        );
         self.surface_to_window.insert(surface_id, window);
 
         let mut data = SurfaceData::new(surface_id);
         data.workspace = self.active_workspace;
+        data.geometry = initial_geometry;
         self.surfaces.insert(surface_id, data);
 
         // Emit IPC event
@@ -52,6 +69,7 @@ impl XdgShellHandler for EwwmState {
 
         // Send initial configure
         surface.send_configure();
+        self.reflow_native_layout();
     }
 
     fn new_popup(&mut self, surface: PopupSurface, _positioner: PositionerState) {
@@ -98,7 +116,12 @@ impl XdgShellHandler for EwwmState {
         }
     }
 
-    fn reposition_request(&mut self, surface: PopupSurface, positioner: PositionerState, token: u32) {
+    fn reposition_request(
+        &mut self,
+        surface: PopupSurface,
+        positioner: PositionerState,
+        token: u32,
+    ) {
         surface.with_pending_state(|state| {
             state.geometry = positioner.get_geometry();
             state.positioner = positioner;
@@ -111,11 +134,14 @@ impl XdgShellHandler for EwwmState {
         let wl_surface = surface.wl_surface().clone();
         let surface_id = self.surfaces.iter().find_map(|(id, _data)| {
             // Match by checking space elements
-            self.space.elements().any(|w| {
-                w.toplevel()
-                    .map(|t| *t.wl_surface() == wl_surface)
-                    .unwrap_or(false)
-            }).then_some(*id)
+            self.space
+                .elements()
+                .any(|w| {
+                    w.toplevel()
+                        .map(|t| *t.wl_surface() == wl_surface)
+                        .unwrap_or(false)
+                })
+                .then_some(*id)
         });
 
         if let Some(sid) = surface_id {
@@ -127,15 +153,20 @@ impl XdgShellHandler for EwwmState {
         }
 
         // Remove from space
-        let window = self.space.elements().find(|w| {
-            w.toplevel()
-                .map(|t| *t.wl_surface() == wl_surface)
-                .unwrap_or(false)
-        }).cloned();
+        let window = self
+            .space
+            .elements()
+            .find(|w| {
+                w.toplevel()
+                    .map(|t| *t.wl_surface() == wl_surface)
+                    .unwrap_or(false)
+            })
+            .cloned();
 
         if let Some(w) = window {
             self.space.unmap_elem(&w);
         }
+        self.reflow_native_layout();
     }
 }
 

--- a/compositor/src/handlers/xwayland.rs
+++ b/compositor/src/handlers/xwayland.rs
@@ -44,8 +44,13 @@ impl XwmHandler for EwwmState {
         }
 
         // Create a unified Window element
+        let initial_geometry = self.initial_window_geometry();
         let win = Window::new_x11_window(window.clone());
-        self.space.map_element(win.clone(), (0, 0), false);
+        self.space.map_element(
+            win.clone(),
+            (initial_geometry.loc.x, initial_geometry.loc.y),
+            true,
+        );
 
         // Extract X11 properties
         // Smithay 0.7: class(), instance(), title() return String, not Option<String>
@@ -57,7 +62,11 @@ impl XwmHandler for EwwmState {
 
         // Helper: convert empty strings to None for Option<String> fields
         let non_empty = |s: &str| -> Option<String> {
-            if s.is_empty() { None } else { Some(s.to_string()) }
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
         };
 
         // Create surface data
@@ -67,6 +76,7 @@ impl XwmHandler for EwwmState {
         data.x11_class = non_empty(&wm_class);
         data.x11_instance = non_empty(&wm_instance);
         data.workspace = self.active_workspace;
+        data.geometry = initial_geometry;
 
         // Auto-float transient windows (dialogs)
         if is_transient {
@@ -76,18 +86,20 @@ impl XwmHandler for EwwmState {
         self.surfaces.insert(surface_id, data);
         self.surface_to_window.insert(surface_id, win);
 
-        // Configure the window
-        if let Some(geo) = self.space.elements().last().and_then(|w| {
-            self.space.element_geometry(w)
-        }) {
-            if let Err(e) = window.configure(Some(geo)) {
-                warn!(surface_id, "XWayland: configure failed: {}", e);
-            }
+        // Configure the window to a visible initial rectangle. Newly mapped X11
+        // surfaces may still report a zero bbox, which is not useful for the
+        // first scanout frame.
+        if let Err(e) = window.configure(Some(initial_geometry)) {
+            warn!(surface_id, "XWayland: configure failed: {}", e);
         }
 
         // Emit IPC event with :x11 flag
         // Smithay 0.7: these are String, use as_str() directly
-        let app_id = if wm_class.is_empty() { &wm_instance } else { &wm_class };
+        let app_id = if wm_class.is_empty() {
+            &wm_instance
+        } else {
+            &wm_class
+        };
         let title_str = title.as_str();
         let x11_class_str = wm_class.as_str();
         let x11_instance_str = wm_instance.as_str();
@@ -100,11 +112,15 @@ impl XwmHandler for EwwmState {
                 ("title", &format!("\"{}\"", escape_str(title_str))),
                 ("x11", "t"),
                 ("x11-class", &format!("\"{}\"", escape_str(x11_class_str))),
-                ("x11-instance", &format!("\"{}\"", escape_str(x11_instance_str))),
+                (
+                    "x11-instance",
+                    &format!("\"{}\"", escape_str(x11_instance_str)),
+                ),
                 ("transient", if is_transient { "t" } else { "nil" }),
             ],
         );
         IpcServer::broadcast_event(self, &event);
+        self.reflow_native_layout();
     }
 
     fn mapped_override_redirect_window(&mut self, _xwm: XwmId, _window: X11Surface) {
@@ -138,14 +154,19 @@ impl XwmHandler for EwwmState {
         }
 
         // Remove from space — collect first to avoid borrowing self.space twice
-        let to_unmap = self.space.elements().find(|w| {
-            w.x11_surface()
-                .map(|xs| xs.window_id() == window.window_id())
-                .unwrap_or(false)
-        }).cloned();
+        let to_unmap = self
+            .space
+            .elements()
+            .find(|w| {
+                w.x11_surface()
+                    .map(|xs| xs.window_id() == window.window_id())
+                    .unwrap_or(false)
+            })
+            .cloned();
         if let Some(w) = to_unmap {
             self.space.unmap_elem(&w);
         }
+        self.reflow_native_layout();
     }
 
     fn destroyed_window(&mut self, _xwm: XwmId, _window: X11Surface) {

--- a/compositor/src/input_source.rs
+++ b/compositor/src/input_source.rs
@@ -12,13 +12,31 @@ use std::time::Duration;
 #[derive(Debug, Clone)]
 pub enum InputEvent {
     /// Gaze direction (yaw, pitch in radians).
-    Gaze { yaw: f64, pitch: f64, confidence: f64 },
+    Gaze {
+        yaw: f64,
+        pitch: f64,
+        confidence: f64,
+    },
     /// Hand joint update (left=true/false, joint index 0-25, x/y/z).
-    Hand { left: bool, joint: u8, x: f64, y: f64, z: f64 },
+    Hand {
+        left: bool,
+        joint: u8,
+        x: f64,
+        y: f64,
+        z: f64,
+    },
     /// Blink event (left_closed, right_closed, duration_ms).
-    Blink { left_closed: bool, right_closed: bool, duration_ms: u32 },
+    Blink {
+        left_closed: bool,
+        right_closed: bool,
+        duration_ms: u32,
+    },
     /// Gesture detected.
-    Gesture { name: String, hand: String, confidence: f64 },
+    Gesture {
+        name: String,
+        hand: String,
+        confidence: f64,
+    },
     /// BCI sample (channel, value).
     BciSample { channel: u8, value: f64 },
     /// Raw IPC message string.
@@ -109,9 +127,17 @@ mod tests {
     #[test]
     fn test_scripted_provider() {
         let events = vec![
-            InputEvent::Gaze { yaw: 0.0, pitch: 0.0, confidence: 1.0 },
-            InputEvent::Wait { duration: Duration::from_millis(100) },
-            InputEvent::IpcMessage { payload: "(:type :ping :id 1)".to_string() },
+            InputEvent::Gaze {
+                yaw: 0.0,
+                pitch: 0.0,
+                confidence: 1.0,
+            },
+            InputEvent::Wait {
+                duration: Duration::from_millis(100),
+            },
+            InputEvent::IpcMessage {
+                payload: "(:type :ping :id 1)".to_string(),
+            },
         ];
 
         let mut provider = ScriptedInputProvider::new(events);
@@ -134,8 +160,15 @@ mod tests {
     #[test]
     fn test_recording_provider() {
         let events = vec![
-            InputEvent::BciSample { channel: 0, value: 0.5 },
-            InputEvent::Gesture { name: "pinch".to_string(), hand: "left".to_string(), confidence: 0.9 },
+            InputEvent::BciSample {
+                channel: 0,
+                value: 0.5,
+            },
+            InputEvent::Gesture {
+                name: "pinch".to_string(),
+                hand: "left".to_string(),
+                confidence: 0.9,
+            },
         ];
 
         let scripted = ScriptedInputProvider::new(events);
@@ -164,11 +197,28 @@ mod tests {
     #[test]
     fn test_hand_event() {
         let events = vec![
-            InputEvent::Hand { left: true, joint: 0, x: 0.1, y: 0.2, z: 0.3 },
-            InputEvent::Blink { left_closed: true, right_closed: false, duration_ms: 150 },
+            InputEvent::Hand {
+                left: true,
+                joint: 0,
+                x: 0.1,
+                y: 0.2,
+                z: 0.3,
+            },
+            InputEvent::Blink {
+                left_closed: true,
+                right_closed: false,
+                duration_ms: 150,
+            },
         ];
         let mut provider = ScriptedInputProvider::new(events);
         let e = provider.next_event().unwrap();
-        assert!(matches!(e, InputEvent::Hand { left: true, joint: 0, .. }));
+        assert!(matches!(
+            e,
+            InputEvent::Hand {
+                left: true,
+                joint: 0,
+                ..
+            }
+        ));
     }
 }

--- a/compositor/src/lib.rs
+++ b/compositor/src/lib.rs
@@ -4,12 +4,12 @@
 //! testing. The binary entry point lives in `main.rs`.
 
 pub mod autotype;
+pub mod backend;
 pub mod clock;
 pub mod config;
-pub mod input_source;
-pub mod backend;
 pub(crate) mod handlers;
 pub(crate) mod input;
+pub mod input_source;
 pub mod ipc;
 pub(crate) mod render;
 pub mod secure_input;

--- a/compositor/src/secure_input.rs
+++ b/compositor/src/secure_input.rs
@@ -110,12 +110,7 @@ impl SecureInputState {
     /// Activate secure input mode for the given reason and surface.
     /// The `now` parameter should come from the compositor clock
     /// (`state.clock.now()`) so tests can control time.
-    pub fn enter(
-        &mut self,
-        reason: &str,
-        surface_id: u64,
-        now: std::time::Instant,
-    ) {
+    pub fn enter(&mut self, reason: &str, surface_id: u64, now: std::time::Instant) {
         if self.active {
             debug!(
                 "Secure input mode re-entered: reason=\"{}\" surface_id={}",

--- a/compositor/tests/full_stack_integration.rs
+++ b/compositor/tests/full_stack_integration.rs
@@ -8,7 +8,9 @@
 //! by the unified input abstraction.
 
 use ewwm_compositor::clock::{Clock, TestClock};
-use ewwm_compositor::input_source::{InputEvent, InputProvider, RecordingProvider, ScriptedInputProvider};
+use ewwm_compositor::input_source::{
+    InputEvent, InputProvider, RecordingProvider, ScriptedInputProvider,
+};
 use ewwm_compositor::ipc::recorder::{IpcRecorder, MessageDirection};
 
 use std::sync::Arc;
@@ -73,13 +75,20 @@ fn test_gaze_dwell_focus_with_clock() {
         }) = &event
         {
             assert_eq!(*sid, surface_id);
-            assert!(*dwell_ms >= 200.0, "dwell_ms should be >= 200, got {}", dwell_ms);
+            assert!(
+                *dwell_ms >= 200.0,
+                "dwell_ms should be >= 200, got {}",
+                dwell_ms
+            );
             focus_requested = true;
             break;
         }
     }
 
-    assert!(focus_requested, "FocusRequested should fire after dwell threshold");
+    assert!(
+        focus_requested,
+        "FocusRequested should fire after dwell threshold"
+    );
     assert_eq!(gaze_focus.focused_surface, Some(surface_id));
 }
 
@@ -167,7 +176,11 @@ fn test_pinch_gesture_lifecycle() {
     };
 
     // Other fingertips need to be away from palm (not grab)
-    for joint in &[HandJoint::MiddleTip, HandJoint::RingTip, HandJoint::LittleTip] {
+    for joint in &[
+        HandJoint::MiddleTip,
+        HandJoint::RingTip,
+        HandJoint::LittleTip,
+    ] {
         left.joints[joint.index()] = JointPose {
             position: [0.0, 0.15, 0.0], // extended away
             orientation: [0.0, 0.0, 0.0, 1.0],
@@ -183,7 +196,13 @@ fn test_pinch_gesture_lifecycle() {
     for _frame in 0..10 {
         let events = gesture.update(&left, &right, 16.0);
         for event in &events {
-            if matches!(event, GestureEvent::Started { gesture: GestureType::Pinch, .. }) {
+            if matches!(
+                event,
+                GestureEvent::Started {
+                    gesture: GestureType::Pinch,
+                    ..
+                }
+            ) {
                 pinch_started = true;
             }
         }
@@ -197,9 +216,15 @@ fn test_pinch_gesture_lifecycle() {
     left.joints[HandJoint::IndexTip.index()].position = [0.15, 0.15, 0.0];
 
     let events = gesture.update(&left, &right, 16.0);
-    let released = events
-        .iter()
-        .any(|e| matches!(e, GestureEvent::Released { gesture: GestureType::Pinch, .. }));
+    let released = events.iter().any(|e| {
+        matches!(
+            e,
+            GestureEvent::Released {
+                gesture: GestureType::Pinch,
+                ..
+            }
+        )
+    });
     assert!(released, "Pinch release should be detected");
 }
 
@@ -339,7 +364,11 @@ fn test_full_multi_modal_sequence() {
         total_events += 1;
 
         match event {
-            InputEvent::Gaze { yaw, pitch, confidence } => {
+            InputEvent::Gaze {
+                yaw,
+                pitch,
+                confidence,
+            } => {
                 gaze_events += 1;
                 frame_counter += 1;
                 // Feed to gaze focus manager
@@ -366,7 +395,11 @@ fn test_full_multi_modal_sequence() {
                 clock.advance(duration);
                 wait_total += duration;
             }
-            InputEvent::Gesture { name, hand, confidence } => {
+            InputEvent::Gesture {
+                name,
+                hand,
+                confidence,
+            } => {
                 // Record as IPC event
                 ipc_recorder.record(
                     0,
@@ -431,12 +464,23 @@ fn test_vr_state_stub_subsystem_access() {
     // All subsystems accessible through VrState
     assert!(vr.gaze_focus.focused_surface.is_none());
     assert!(vr.gesture.binding_count() == 0);
-    assert!(matches!(vr.bci.connection, ewwm_compositor::vr::bci_state::BciConnectionState::Disconnected));
+    assert!(matches!(
+        vr.bci.connection,
+        ewwm_compositor::vr::bci_state::BciConnectionState::Disconnected
+    ));
     // Stub and real VrState have different frame_stats_sexp formats;
     // just verify it starts with "(:" and contains "fps 0"
     let stats = vr.frame_stats_sexp();
-    assert!(stats.starts_with("(:"), "frame_stats_sexp should start with '(:' got '{}'", stats);
-    assert!(stats.contains("fps 0"), "frame_stats_sexp should contain 'fps 0' got '{}'", stats);
+    assert!(
+        stats.starts_with("(:"),
+        "frame_stats_sexp should start with '(:' got '{}'",
+        stats
+    );
+    assert!(
+        stats.contains("fps 0"),
+        "frame_stats_sexp should contain 'fps 0' got '{}'",
+        stats
+    );
 }
 
 // ── Deterministic dwell with TestClock driving timing ────────
@@ -491,7 +535,11 @@ fn test_deterministic_dwell_with_test_clock() {
         let event = gaze_focus.update(Some(&hit), Some(&gaze_t), 0.020);
         match &event {
             Some(GazeFocusEvent::DwellProgress { elapsed_ms, .. }) => {
-                assert!(*elapsed_ms < 100.0, "should not reach threshold yet at {}ms", elapsed_ms);
+                assert!(
+                    *elapsed_ms < 100.0,
+                    "should not reach threshold yet at {}ms",
+                    elapsed_ms
+                );
             }
             other => {
                 // May get other events (cooldown, etc.) — skip
@@ -522,7 +570,10 @@ fn test_deterministic_dwell_with_test_clock() {
             break;
         }
     }
-    assert!(focus_triggered, "focus should be requested after 100ms dwell threshold");
+    assert!(
+        focus_triggered,
+        "focus should be requested after 100ms dwell threshold"
+    );
     assert_eq!(gaze_focus.focused_surface, Some(7));
 }
 
@@ -580,7 +631,10 @@ fn test_ipc_record_replay_round_trip() {
             "request should contain type"
         );
     }
-    assert_eq!(request_count, 5, "should extract 5 requests from 10 messages");
+    assert_eq!(
+        request_count, 5,
+        "should extract 5 requests from 10 messages"
+    );
     assert_eq!(replayer.consumed, 10);
 }
 
@@ -673,9 +727,19 @@ fn test_multi_surface_focus_switching() {
 #[test]
 fn test_recording_provider_preserves_order() {
     let events = vec![
-        InputEvent::BciSample { channel: 0, value: 0.1 },
-        InputEvent::BciSample { channel: 1, value: 0.2 },
-        InputEvent::Gaze { yaw: 0.5, pitch: 0.3, confidence: 0.9 },
+        InputEvent::BciSample {
+            channel: 0,
+            value: 0.1,
+        },
+        InputEvent::BciSample {
+            channel: 1,
+            value: 0.2,
+        },
+        InputEvent::Gaze {
+            yaw: 0.5,
+            pitch: 0.3,
+            confidence: 0.9,
+        },
         InputEvent::Gesture {
             name: "grab".to_string(),
             hand: "left".to_string(),
@@ -716,8 +780,14 @@ fn test_recording_provider_preserves_order() {
     assert_eq!(recorded.len(), 8);
 
     // Verify ordering
-    assert!(matches!(recorded[0], InputEvent::BciSample { channel: 0, .. }));
-    assert!(matches!(recorded[1], InputEvent::BciSample { channel: 1, .. }));
+    assert!(matches!(
+        recorded[0],
+        InputEvent::BciSample { channel: 0, .. }
+    ));
+    assert!(matches!(
+        recorded[1],
+        InputEvent::BciSample { channel: 1, .. }
+    ));
     assert!(matches!(recorded[2], InputEvent::Gaze { .. }));
     assert!(matches!(recorded[3], InputEvent::Gesture { .. }));
     assert!(matches!(recorded[4], InputEvent::Blink { .. }));
@@ -738,7 +808,10 @@ fn test_shared_clock_across_subsystems() {
     let clock: Arc<dyn Clock> = Arc::new(TestClock::new());
     let now1 = clock.now();
     let now2 = clock.now();
-    assert_eq!(now1, now2, "same clock should return same time without advance");
+    assert_eq!(
+        now1, now2,
+        "same clock should return same time without advance"
+    );
 
     let ms1 = clock.unix_millis();
     let ms2 = clock.unix_millis();

--- a/compositor/tests/headless_integration.rs
+++ b/compositor/tests/headless_integration.rs
@@ -8,12 +8,8 @@
 //! wayland-server support. These tests focus on the logic layer.
 
 use ewwm_compositor::clock::{Clock, TestClock};
-use ewwm_compositor::ipc::recorder::{
-    IpcRecorder, IpcReplayer, MessageDirection, RecordedMessage,
-};
-use ewwm_compositor::input_source::{
-    InputEvent, InputProvider, ScriptedInputProvider,
-};
+use ewwm_compositor::input_source::{InputEvent, InputProvider, ScriptedInputProvider};
+use ewwm_compositor::ipc::recorder::{IpcRecorder, IpcReplayer, MessageDirection, RecordedMessage};
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -80,11 +76,7 @@ fn test_recorder_full_session() {
     );
 
     // Simulate a surface-list
-    rec.record(
-        1,
-        MessageDirection::Request,
-        "(:type :surface-list :id 3)",
-    );
+    rec.record(1, MessageDirection::Request, "(:type :surface-list :id 3)");
     rec.record(
         1,
         MessageDirection::Response,
@@ -187,8 +179,7 @@ fn test_scripted_input_multi_modal_sequence() {
         },
         // Send IPC command
         InputEvent::IpcMessage {
-            payload: "(:type :surface-focus :id 1 :surface-id 42)"
-                .to_string(),
+            payload: "(:type :surface-focus :id 1 :surface-id 42)".to_string(),
         },
     ];
 
@@ -217,8 +208,7 @@ fn test_scripted_input_multi_modal_sequence() {
 #[test]
 fn test_secure_input_state_with_clock() {
     let clock = TestClock::new();
-    let mut state =
-        ewwm_compositor::secure_input::SecureInputState::new();
+    let mut state = ewwm_compositor::secure_input::SecureInputState::new();
 
     let now = clock.now();
     state.enter("test-password", 42, now);
@@ -242,8 +232,7 @@ fn test_secure_input_state_with_clock() {
 #[test]
 fn test_secure_input_status_sexp_with_clock() {
     let clock = TestClock::new();
-    let mut state =
-        ewwm_compositor::secure_input::SecureInputState::new();
+    let mut state = ewwm_compositor::secure_input::SecureInputState::new();
 
     let now = clock.now();
     state.enter("sudo", 7, now);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -676,7 +676,7 @@ Multi-modal fusion (gaze + EEG + gesture).
 | `:surface-created` | `:id :app-id :title` | New surface |
 | `:surface-destroyed` | `:id` | Surface closed |
 | `:surface-title-changed` | `:id :title` | Title updated |
-| `:surface-focused` | `:id` | Focus changed |
+| `:surface-focused` | `:id :previous-id` | Canonical focus changed event |
 | `:surface-geometry-changed` | `:id :geometry` | Geometry changed |
 | `:workspace-changed` | `:workspace` | Workspace switched |
 | `:key-pressed` | `:key :modifiers :timestamp` | Grabbed key pressed |

--- a/test/v040-focus-cursor-test.el
+++ b/test/v040-focus-cursor-test.el
@@ -123,11 +123,21 @@
 
 ;; ── Focus event format ─────────────────────────────────────
 
-(ert-deftest v040/focus-event-has-old-and-new ()
-  "focus-changed event includes :old and :new fields."
+(ert-deftest v040/focus-event-has-canonical-surface-focused ()
+  "surface-focused is the canonical focus event."
   (let ((file (expand-file-name "compositor/src/handlers/seat.rs" v040-test--root)))
     (with-temp-buffer
       (insert-file-contents file)
+      (should (search-forward "surface-focused" nil t))
+      (should (search-forward "(\"id\"" nil t))
+      (should (search-forward "(\"previous-id\"" nil t)))))
+
+(ert-deftest v040/focus-event-keeps-compat-alias ()
+  "focus-changed remains a temporary compatibility alias."
+  (let ((file (expand-file-name "compositor/src/handlers/seat.rs" v040-test--root)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (should (search-forward "focus-changed" nil t))
       (should (search-forward "(\"old\"" nil t))
       (should (search-forward "(\"new\"" nil t)))))
 


### PR DESCRIPTION
Refs #45. Issue set: #60, #61, #67, #68, #69, #70. Stacked on #75.

## Scope
- Wires native runtime policy through backend/handler surfaces.
- Keeps focus, surface geometry, workspace visibility, layout reflow, DPMS, and session policy in the compositor path.
- Updates integration/static coverage for runtime policy behavior.

## Validation
- cargo fmt --manifest-path compositor/Cargo.toml --check
- cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features
- just native-authority-test
- Verified on final stack tip: just test

Issue closure should happen only after the implementing PR has merged.