### PR TITLE
native-authority: Emacs app-layer bridge

### DIFF
--- a/lisp/vr/ewwm-floating.el
+++ b/lisp/vr/ewwm-floating.el
@@ -35,12 +35,14 @@ When nil, use `pop-to-buffer' in a side window."
 Sends IPC to compositor and updates buffer state."
   (interactive)
   (let ((sid (or surface-id
-                 (and (derived-mode-p 'ewwm-mode) ewwm-surface-id))))
+                 (and (derived-mode-p 'ewwm-mode) ewwm-surface-id)))
+        (enable t))
     (when sid
       (when-let ((buf (ewwm--get-buffer sid)))
         (with-current-buffer buf
           (setq ewwm-surface-state
                 (if (eq ewwm-surface-state 'floating) 'managed 'floating))
+          (setq enable (eq ewwm-surface-state 'floating))
           (when (derived-mode-p 'ewwm-mode)
             (ewwm--refresh-buffer-content))))
       ;; Send IPC
@@ -48,7 +50,7 @@ Sends IPC to compositor and updates buffer state."
                  (fboundp 'ewwm-ipc-connected-p)
                  (funcall 'ewwm-ipc-connected-p))
         (funcall 'ewwm-ipc-send
-                 `(:type :surface-float :surface-id ,sid)))
+                 `(:type :surface-float :surface-id ,sid :enable ,enable)))
       ;; Re-layout current workspace (floating surface removed/added to tiling)
       (when (and (boundp 'ewwm-workspace-current-index)
                  (fboundp 'ewwm-layout--apply-current))

--- a/lisp/vr/ewwm-input.el
+++ b/lisp/vr/ewwm-input.el
@@ -43,6 +43,18 @@ KEY-DESCRIPTION is a string like \"s-r\" or \"C-M-x\".")
 (defvar ewwm-input--suppress-focus-sync nil
   "Non-nil to suppress focus sync during programmatic buffer switches.")
 
+(defun ewwm-input--native-connected-p ()
+  "Return non-nil when native compositor IPC is connected."
+  (and (fboundp 'ewwm-ipc-connected-p)
+       (funcall 'ewwm-ipc-connected-p)
+       (fboundp 'ewwm-ipc-send)))
+
+(defun ewwm-input--native-or-fallback (request fallback)
+  "Send native IPC REQUEST when connected, otherwise call FALLBACK."
+  (if (ewwm-input--native-connected-p)
+      (funcall 'ewwm-ipc-send request)
+    (funcall fallback)))
+
 ;; ── Key registration ─────────────────────────────────────────
 
 (defun ewwm-input-set-key (key command)
@@ -108,8 +120,11 @@ Does not send IPC — call `ewwm-input--register-all-grabs' after connecting."
           (ws i))
       (setf (alist-get key ewwm-input--global-keys nil nil #'equal)
             (lambda () (interactive)
-              (when (fboundp 'ewwm-workspace-switch)
-                (funcall 'ewwm-workspace-switch ws))))))
+              (ewwm-input--native-or-fallback
+               `(:type :workspace-switch :workspace ,ws)
+               (lambda ()
+                 (when (fboundp 'ewwm-workspace-switch)
+                   (funcall 'ewwm-workspace-switch ws))))))))
   ;; Move surface to workspace: s-S-1 through s-S-9
   (dotimes (i 9)
     (let ((key (format "s-S-%d" (1+ i)))
@@ -118,12 +133,20 @@ Does not send IPC — call `ewwm-input--register-all-grabs' after connecting."
             (lambda () (interactive)
               (when (and ewwm-surface-id
                          (fboundp 'ewwm-workspace-move-surface))
-                (funcall 'ewwm-workspace-move-surface ewwm-surface-id ws))))))
+                (ewwm-input--native-or-fallback
+                 `(:type :workspace-move-surface
+                         :surface-id ,ewwm-surface-id
+                         :workspace ,ws)
+                 (lambda ()
+                   (funcall 'ewwm-workspace-move-surface ewwm-surface-id ws))))))))
   ;; Layout cycling
   (setf (alist-get "s-SPC" ewwm-input--global-keys nil nil #'equal)
         (lambda () (interactive)
-          (when (fboundp 'ewwm-layout-cycle)
-            (funcall 'ewwm-layout-cycle))))
+          (ewwm-input--native-or-fallback
+           '(:type :layout-cycle)
+           (lambda ()
+             (when (fboundp 'ewwm-layout-cycle)
+               (funcall 'ewwm-layout-cycle))))))
   ;; App launcher
   (setf (alist-get "s-&" ewwm-input--global-keys nil nil #'equal)
         (lambda () (interactive)
@@ -133,8 +156,11 @@ Does not send IPC — call `ewwm-input--register-all-grabs' after connecting."
   ;; Reset
   (setf (alist-get "s-r" ewwm-input--global-keys nil nil #'equal)
         (lambda () (interactive)
-          (when (fboundp 'ewwm-reset)
-            (funcall 'ewwm-reset)))))
+          (ewwm-input--native-or-fallback
+           '(:type :config-reload)
+           (lambda ()
+             (when (fboundp 'ewwm-reset)
+               (funcall 'ewwm-reset)))))))
 
 ;; ── Intercept mode toggle ────────────────────────────────────
 

--- a/lisp/vr/ewwm-ipc.el
+++ b/lisp/vr/ewwm-ipc.el
@@ -42,8 +42,14 @@
     (:surface-destroyed  . ewwm-ipc--on-surface-destroyed)
     (:surface-title-changed . ewwm-ipc--on-surface-title-changed)
     (:surface-focused    . ewwm-ipc--on-surface-focused)
+    (:focus-changed      . ewwm-ipc--on-focus-changed-compat)
+    (:surface-float-changed . ewwm-ipc--on-surface-float-changed)
+    (:surface-workspace-changed . ewwm-ipc--on-surface-workspace-changed)
     (:surface-geometry-changed . ewwm-ipc--on-surface-geometry-changed)
     (:workspace-changed  . ewwm-ipc--on-workspace-changed)
+    (:layout-changed     . ewwm-ipc--on-layout-changed)
+    (:autostart-ran      . ewwm-ipc--on-autostart-ran)
+    (:config-reloaded    . ewwm-ipc--on-config-reloaded)
     (:key-pressed        . ewwm-ipc--on-key-pressed)
     (:output-usable-area-changed . ewwm-ipc--on-output-usable-area-changed))
   "Alist mapping event types to handler functions.")
@@ -310,15 +316,64 @@ TIMEOUT defaults to `ewwm-ipc-sync-timeout' seconds."
   (let ((id (plist-get msg :id)))
     (message "ewwm: surface focused: id=%d" id)))
 
+(defun ewwm-ipc--on-focus-changed-compat (msg)
+  "Handle legacy :focus-changed event MSG.
+
+The canonical compositor event is now :surface-focused with :id and
+:previous-id.  This compatibility handler preserves older Rust/runtime
+surfaces that still emit :old/:new."
+  (ewwm-ipc--on-surface-focused
+   (list :type :event
+         :event :surface-focused
+         :id (plist-get msg :new)
+         :previous-id (plist-get msg :old))))
+
 (defun ewwm-ipc--on-surface-geometry-changed (_msg)
   "Handle :surface-geometry-changed event MSG."
   ;; Silent — high frequency
   nil)
 
+(defun ewwm-ipc--on-surface-float-changed (msg)
+  "Mirror native :surface-float-changed MSG into the app-layer buffer."
+  (when-let ((buf (and (fboundp 'ewwm--get-buffer)
+                       (ewwm--get-buffer (plist-get msg :id)))))
+    (with-current-buffer buf
+      (setq ewwm-surface-state
+            (if (plist-get msg :floating) 'floating 'managed))
+      (when (derived-mode-p 'ewwm-mode)
+        (ewwm--refresh-buffer-content)))))
+
+(defun ewwm-ipc--on-surface-workspace-changed (msg)
+  "Mirror native :surface-workspace-changed MSG into the app-layer buffer."
+  (when-let ((buf (and (fboundp 'ewwm--get-buffer)
+                       (ewwm--get-buffer (plist-get msg :id)))))
+    (with-current-buffer buf
+      (setq ewwm-workspace (plist-get msg :new-workspace)))))
+
 (defun ewwm-ipc--on-workspace-changed (msg)
   "Handle :workspace-changed event MSG."
   (let ((workspace (plist-get msg :workspace)))
+    (when (boundp 'ewwm-workspace-current-index)
+      (setq ewwm-workspace-current-index workspace))
     (message "ewwm: workspace changed: %d" workspace)))
+
+(defun ewwm-ipc--on-layout-changed (msg)
+  "Handle native :layout-changed event MSG."
+  (when (and (boundp 'ewwm-layout--current)
+             (plist-get msg :layout))
+    (setq ewwm-layout--current (intern (plist-get msg :layout)))))
+
+(defun ewwm-ipc--on-autostart-ran (msg)
+  "Handle native :autostart-ran event MSG."
+  (message "ewwm: autostart ran: %s" (plist-get msg :target)))
+
+(defun ewwm-ipc--on-config-reloaded (msg)
+  "Handle native :config-reloaded event MSG."
+  (when (plist-get msg :layout)
+    (setq ewwm-layout--current (intern (plist-get msg :layout))))
+  (when (plist-get msg :active-workspace)
+    (setq ewwm-workspace-current-index (plist-get msg :active-workspace)))
+  (message "ewwm: native config reloaded"))
 
 (defun ewwm-ipc--on-key-pressed (msg)
   "Handle :key-pressed event MSG."
@@ -385,18 +440,24 @@ Updates layout usable area when layer-shell exclusive zones change."
   "Resize SURFACE-ID to dimensions (W, H)."
   (ewwm-ipc-send `(:type :surface-resize :surface-id ,surface-id :w ,w :h ,h)))
 
-(defun ewwm-workspace-switch (n)
-  "Switch to workspace N."
+(defun ewwm-ipc-workspace-switch (n)
+  "Switch to workspace N through raw compositor IPC."
   (interactive "nWorkspace: ")
   (ewwm-ipc-send `(:type :workspace-switch :workspace ,n)))
 
-(defun ewwm-workspace-list ()
-  "Query the compositor for workspace state."
+(defun ewwm-ipc-workspace-list ()
+  "Query the compositor for workspace state through raw IPC."
   (interactive)
   (let ((resp (ewwm-ipc-send-sync '(:type :workspace-list))))
     (if (eq (plist-get resp :status) :ok)
         (plist-get resp :workspaces)
       (error "ewwm: workspace-list failed: %s" (plist-get resp :reason)))))
+
+(unless (fboundp 'ewwm-workspace-switch)
+  (defalias 'ewwm-workspace-switch #'ewwm-ipc-workspace-switch))
+
+(unless (fboundp 'ewwm-workspace-list)
+  (defalias 'ewwm-workspace-list #'ewwm-ipc-workspace-list))
 
 (defun ewwm-key-grab (key)
   "Register a global key grab for KEY (Emacs key description)."

--- a/lisp/vr/ewwm-launch.el
+++ b/lisp/vr/ewwm-launch.el
@@ -11,6 +11,10 @@
 (require 'cl-lib)
 (require 'ewwm-core)
 
+(declare-function ewwm-ipc-send "ewwm-ipc")
+(declare-function ewwm-ipc-send-sync "ewwm-ipc")
+(declare-function ewwm-ipc-connected-p "ewwm-ipc")
+
 ;; ── Customization ────────────────────────────────────────────
 
 (defgroup ewwm-launch nil
@@ -83,6 +87,27 @@ Sets WAYLAND_DISPLAY, XDG_RUNTIME_DIR, and any extra env vars."
   (interactive)
   (let ((cmd (completing-read "Launch favorite: " ewwm-launch-favorites nil t)))
     (ewwm-launch cmd)))
+
+(defun ewwm-launch-native-target-list ()
+  "Return configured native app-launch target names from the compositor."
+  (interactive)
+  (let ((resp (funcall 'ewwm-ipc-send-sync '(:type :app-launch-list))))
+    (if (eq (plist-get resp :status) :ok)
+        (let ((targets (plist-get resp :targets)))
+          (when (called-interactively-p 'interactive)
+            (message "ewwm native targets: %S" targets))
+          targets)
+      (error "ewwm native target list failed: %s" (plist-get resp :reason)))))
+
+(defun ewwm-launch-native-target (target)
+  "Ask the native compositor to launch configured TARGET."
+  (interactive
+   (list (completing-read "Native launch target: "
+                          (when (and (fboundp 'ewwm-ipc-connected-p)
+                                     (funcall 'ewwm-ipc-connected-p))
+                            (ewwm-launch-native-target-list))
+                          nil t)))
+  (funcall 'ewwm-ipc-send `(:type :app-launch :target ,target)))
 
 ;; ── Process management ───────────────────────────────────────
 

--- a/lisp/vr/ewwm-layout.el
+++ b/lisp/vr/ewwm-layout.el
@@ -169,22 +169,35 @@ BUFFERS list determines which buffer is visible."
    (list (intern (completing-read "Layout: "
                                   (mapcar #'symbol-name ewwm-layout--cycle-list)
                                   nil t))))
-  (setq ewwm-layout--current layout)
-  (ewwm-layout--apply-current
-   (ewwm--buffers-on-workspace
-    (if (boundp 'ewwm-workspace-current-index)
-        ewwm-workspace-current-index
-      0)))
-  (run-hook-with-args 'ewwm-layout-change-hook layout)
-  (message "ewwm: layout %s" layout))
+  (if (and (fboundp 'ewwm-ipc-send)
+           (fboundp 'ewwm-ipc-connected-p)
+           (funcall 'ewwm-ipc-connected-p))
+      (funcall 'ewwm-ipc-send
+               `(:type :layout-set :layout ,(symbol-name layout))
+               (lambda (msg)
+                 (when (eq (plist-get msg :status) :ok)
+                   (setq ewwm-layout--current layout)
+                   (run-hook-with-args 'ewwm-layout-change-hook layout))))
+    (setq ewwm-layout--current layout)
+    (ewwm-layout--apply-current
+     (ewwm--buffers-on-workspace
+      (if (boundp 'ewwm-workspace-current-index)
+          ewwm-workspace-current-index
+        0)))
+    (run-hook-with-args 'ewwm-layout-change-hook layout)
+    (message "ewwm: layout %s" layout)))
 
 (defun ewwm-layout-cycle ()
   "Cycle through available layouts."
   (interactive)
-  (let* ((pos (cl-position ewwm-layout--current ewwm-layout--cycle-list))
-         (next-pos (mod (1+ (or pos 0)) (length ewwm-layout--cycle-list)))
-         (next (nth next-pos ewwm-layout--cycle-list)))
-    (ewwm-layout-set next)))
+  (if (and (fboundp 'ewwm-ipc-send)
+           (fboundp 'ewwm-ipc-connected-p)
+           (funcall 'ewwm-ipc-connected-p))
+      (funcall 'ewwm-ipc-send '(:type :layout-cycle))
+    (let* ((pos (cl-position ewwm-layout--current ewwm-layout--cycle-list))
+           (next-pos (mod (1+ (or pos 0)) (length ewwm-layout--cycle-list)))
+           (next (nth next-pos ewwm-layout--cycle-list)))
+      (ewwm-layout-set next))))
 
 (defun ewwm-layout-current ()
   "Return the current layout mode."

--- a/lisp/vr/ewwm-manage.el
+++ b/lisp/vr/ewwm-manage.el
@@ -149,19 +149,21 @@ Returns the actions plist from the first matching rule, or nil."
   "Toggle fullscreen for SURFACE-ID or current surface."
   (interactive)
   (let ((sid (or surface-id
-                 (and (derived-mode-p 'ewwm-mode) ewwm-surface-id))))
+                 (and (derived-mode-p 'ewwm-mode) ewwm-surface-id)))
+        (enable t))
     (when sid
       (when-let ((buf (ewwm--get-buffer sid)))
         (with-current-buffer buf
           (setq ewwm-surface-state
                 (if (eq ewwm-surface-state 'fullscreen) 'managed 'fullscreen))
+          (setq enable (eq ewwm-surface-state 'fullscreen))
           (when (derived-mode-p 'ewwm-mode)
             (ewwm--refresh-buffer-content))))
       (when (and (fboundp 'ewwm-ipc-send)
                  (fboundp 'ewwm-ipc-connected-p)
                  (funcall 'ewwm-ipc-connected-p))
         (funcall 'ewwm-ipc-send
-                 `(:type :surface-fullscreen :surface-id ,sid))))))
+                 `(:type :surface-fullscreen :surface-id ,sid :enable ,enable))))))
 
 ;; ── XWayland surface queries ────────────────────────────────
 

--- a/lisp/vr/ewwm-session.el
+++ b/lisp/vr/ewwm-session.el
@@ -11,6 +11,10 @@
 
 (require 'cl-lib)
 
+(declare-function ewwm-ipc-send "ewwm-ipc")
+(declare-function ewwm-ipc-send-sync "ewwm-ipc")
+(declare-function ewwm-ipc-connected-p "ewwm-ipc")
+
 ;; ── Customization ────────────────────────────────────────────
 
 (defgroup ewwm-session nil
@@ -66,27 +70,37 @@ Default: lock after 5 min, DPMS off after 10 min, lock before sleep."
 (defvar ewwm-session-lock-process nil
   "Process object for the lock screen.")
 
+(defun ewwm-session--native-connected-p ()
+  "Return non-nil when native compositor session IPC is connected."
+  (and (fboundp 'ewwm-ipc-connected-p)
+       (funcall 'ewwm-ipc-connected-p)
+       (fboundp 'ewwm-ipc-send)))
+
 ;; ── Lock ─────────────────────────────────────────────────────
 
 (defun ewwm-session-lock ()
   "Lock the session by starting the lock command."
   (interactive)
-  (if (and ewwm-session-lock-process
-           (process-live-p ewwm-session-lock-process))
+  (if (ewwm-session--native-connected-p)
+      (progn
+        (funcall 'ewwm-ipc-send '(:type :session-lock))
+        (message "ewwm-session: requested native lock"))
+    (if (and ewwm-session-lock-process
+             (process-live-p ewwm-session-lock-process))
       (message "ewwm-session: screen already locked")
-    (let ((proc (if (fboundp 'ewwm-launch)
-                    (ewwm-launch
-                     (mapconcat #'identity
-                                (cons ewwm-session-lock-command
-                                      ewwm-session-lock-args)
-                                " "))
-                  (apply #'start-process
-                         "ewwm-lock" " *ewwm-lock*"
-                         ewwm-session-lock-command
-                         ewwm-session-lock-args))))
-      (setq ewwm-session-lock-process proc)
-      (set-process-sentinel proc #'ewwm-session--lock-sentinel)
-      (message "ewwm-session: locked"))))
+      (let ((proc (if (fboundp 'ewwm-launch)
+                      (ewwm-launch
+                       (mapconcat #'identity
+                                  (cons ewwm-session-lock-command
+                                        ewwm-session-lock-args)
+                                  " "))
+                    (apply #'start-process
+                           "ewwm-lock" " *ewwm-lock*"
+                           ewwm-session-lock-command
+                           ewwm-session-lock-args))))
+        (setq ewwm-session-lock-process proc)
+        (set-process-sentinel proc #'ewwm-session--lock-sentinel)
+        (message "ewwm-session: locked")))))
 
 (defun ewwm-session--lock-sentinel (proc _event)
   "Clean up when lock PROC exits."
@@ -105,7 +119,7 @@ Sends exit command to the compositor via IPC, or calls `ewwm-exit'."
      ((and (fboundp 'ewwm-ipc-connected-p)
            (funcall 'ewwm-ipc-connected-p)
            (fboundp 'ewwm-ipc-send))
-      (funcall 'ewwm-ipc-send '(:type :compositor-exit))
+      (funcall 'ewwm-ipc-send '(:type :session-logout))
       (message "ewwm-session: sent exit to compositor"))
      ;; Fall back to ewwm-exit
      ((fboundp 'ewwm-exit)
@@ -145,31 +159,39 @@ Sends exit command to the compositor via IPC, or calls `ewwm-exit'."
 (defun ewwm-session-start-idle ()
   "Start the idle management daemon."
   (interactive)
-  (if (and ewwm-session-idle-process
-           (process-live-p ewwm-session-idle-process))
+  (if (ewwm-session--native-connected-p)
+      (progn
+        (funcall 'ewwm-ipc-send '(:type :session-idle-start))
+        (message "ewwm-session: requested native idle supervision"))
+    (if (and ewwm-session-idle-process
+             (process-live-p ewwm-session-idle-process))
       (message "ewwm-session: idle daemon already running")
-    (let ((proc (if (fboundp 'ewwm-launch)
-                    (ewwm-launch
-                     (mapconcat #'identity
-                                (cons ewwm-session-idle-command
-                                      ewwm-session-idle-args)
-                                " "))
-                  (apply #'start-process
-                         "ewwm-idle" " *ewwm-idle*"
-                         ewwm-session-idle-command
-                         ewwm-session-idle-args))))
-      (setq ewwm-session-idle-process proc)
-      (set-process-sentinel proc #'ewwm-session--idle-sentinel)
-      (message "ewwm-session: idle daemon started"))))
+      (let ((proc (if (fboundp 'ewwm-launch)
+                      (ewwm-launch
+                       (mapconcat #'identity
+                                  (cons ewwm-session-idle-command
+                                        ewwm-session-idle-args)
+                                  " "))
+                    (apply #'start-process
+                           "ewwm-idle" " *ewwm-idle*"
+                           ewwm-session-idle-command
+                           ewwm-session-idle-args))))
+        (setq ewwm-session-idle-process proc)
+        (set-process-sentinel proc #'ewwm-session--idle-sentinel)
+        (message "ewwm-session: idle daemon started")))))
 
 (defun ewwm-session-stop-idle ()
   "Stop the idle management daemon."
   (interactive)
-  (when (and ewwm-session-idle-process
-             (process-live-p ewwm-session-idle-process))
-    (kill-process ewwm-session-idle-process))
-  (setq ewwm-session-idle-process nil)
-  (message "ewwm-session: idle daemon stopped"))
+  (if (ewwm-session--native-connected-p)
+      (progn
+        (funcall 'ewwm-ipc-send '(:type :session-idle-stop))
+        (message "ewwm-session: requested native idle stop"))
+    (when (and ewwm-session-idle-process
+               (process-live-p ewwm-session-idle-process))
+      (kill-process ewwm-session-idle-process))
+    (setq ewwm-session-idle-process nil)
+    (message "ewwm-session: idle daemon stopped")))
 
 (defun ewwm-session--idle-sentinel (proc _event)
   "Clean up when idle daemon PROC exits."
@@ -182,13 +204,30 @@ Sends exit command to the compositor via IPC, or calls `ewwm-exit'."
 (defun ewwm-session-status ()
   "Display session status in the minibuffer."
   (interactive)
-  (message "ewwm-session: idle=%s lock=%s"
-           (if (and ewwm-session-idle-process
-                    (process-live-p ewwm-session-idle-process))
-               "running" "stopped")
-           (if (and ewwm-session-lock-process
-                    (process-live-p ewwm-session-lock-process))
-               "active" "inactive")))
+  (if (and (ewwm-session--native-connected-p)
+           (fboundp 'ewwm-ipc-send-sync))
+      (message "ewwm-session: native %S"
+               (funcall 'ewwm-ipc-send-sync '(:type :session-status)))
+    (message "ewwm-session: idle=%s lock=%s"
+             (if (and ewwm-session-idle-process
+                      (process-live-p ewwm-session-idle-process))
+                 "running" "stopped")
+             (if (and ewwm-session-lock-process
+                      (process-live-p ewwm-session-lock-process))
+                 "active" "inactive"))))
+
+(defun ewwm-dpms-get ()
+  "Return native DPMS state through compositor IPC."
+  (interactive)
+  (let ((resp (funcall 'ewwm-ipc-send-sync '(:type :dpms-get))))
+    (if (called-interactively-p 'interactive)
+        (message "ewwm-dpms: %s" (plist-get resp :dpms-state))
+      resp)))
+
+(defun ewwm-dpms-set (state)
+  "Set native DPMS STATE through compositor IPC."
+  (interactive "sDPMS state: ")
+  (funcall 'ewwm-ipc-send `(:type :dpms-set :state ,state)))
 
 (provide 'ewwm-session)
 ;;; ewwm-session.el ends here

--- a/lisp/vr/ewwm.el
+++ b/lisp/vr/ewwm.el
@@ -103,7 +103,8 @@
 (defun ewwm--on-compositor-focus (msg)
   "Handle compositor focus change event MSG."
   (when (memq ewwm-focus-policy '(follow-compositor follow-emacs))
-    (let* ((surface-id (plist-get msg :id))
+    (let* ((surface-id (or (plist-get msg :id)
+                           (plist-get msg :new)))
            (buf (ewwm--get-buffer surface-id)))
       (when (and buf (buffer-live-p buf))
         (let ((ewwm-input--suppress-focus-sync t))

--- a/test/ewwm-ipc-test.el
+++ b/test/ewwm-ipc-test.el
@@ -4,6 +4,7 @@
 
 (require 'ert)
 (require 'ewwm-ipc)
+(require 'ewwm-workspace)
 
 ;; ── Message encoding/decoding tests ────────────────────────
 


### PR DESCRIPTION
Refs #45. Issue set: #71, #72, #73. Stacked on #76.

## Scope
- Keeps Emacs/eGreg helpers available as app-layer clients.
- Routes connected key/layout/surface/session/launcher helpers through native IPC.
- Preserves disconnected fallback behavior for editor-only/debug sessions and uses explicit raw IPC helper names.

## Validation
- just ipc-contract-test
- just native-authority-test
- just test

Issue closure should happen only after the implementing PR has merged.