### PR TITLE
native-authority: proof and packaging boundary

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,6 +104,10 @@ package-no-default-lisp-core-assert:
     snippet = spec[start:end]
     if "exwm-vr/core" in snippet:
         raise SystemExit("default package init must not add lisp/core to load-path")
+    if "packaging/scripts/xoxdwm-native-authority-proof" not in spec:
+        raise SystemExit("RPM must install native-authority-proof helper")
+    if "%{_libexecdir}/%{project_name}/native-authority-proof" not in spec:
+        raise SystemExit("RPM compositor package must own native-authority-proof helper")
     print("package_no_default_lisp_core=passed")
     PY
 

--- a/justfile
+++ b/justfile
@@ -25,8 +25,15 @@ build:
 
 [group('build')]
 build-compositor:
-    @echo "Building compositor (Rust)..."
-    cargo build --manifest-path "{{project_root}}/compositor/Cargo.toml"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building compositor (Rust)..."
+    if [[ "$(uname -s)" = "Linux" ]]; then
+        cargo build --manifest-path "{{project_root}}/compositor/Cargo.toml" \
+            --features full-backend
+    else
+        cargo build --manifest-path "{{project_root}}/compositor/Cargo.toml"
+    fi
 
 [group('build')]
 build-all: build build-compositor
@@ -42,8 +49,15 @@ test:
 
 [group('test')]
 test-compositor:
-    @echo "Running compositor tests..."
-    cargo test --manifest-path "{{project_root}}/compositor/Cargo.toml"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Running compositor tests..."
+    if [[ "$(uname -s)" = "Linux" ]]; then
+        cargo test --manifest-path "{{project_root}}/compositor/Cargo.toml" \
+            --features full-backend
+    else
+        cargo check --manifest-path "{{project_root}}/compositor/Cargo.toml" --tests
+    fi
 
 [group('test')]
 test-integration:
@@ -62,6 +76,42 @@ truth-lint:
         -l "{{project_root}}/test/run-tests.el"
 
 [group('test')]
+native-authority-test:
+    @echo "Running native authority static tests..."
+    emacs --batch \
+        {{load_flags}} \
+        -l "{{project_root}}/test/native-authority-test.el" \
+        -f ert-run-tests-batch-and-exit
+
+[group('test')]
+ipc-contract-test:
+    @echo "Running IPC contract tests..."
+    emacs --batch \
+        {{load_flags}} \
+        -l "{{project_root}}/test/ipc-contract-test.el" \
+        -f ert-run-tests-batch-and-exit
+
+[group('test')]
+package-no-default-lisp-core-assert:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    python3 - <<'PY'
+    from pathlib import Path
+
+    spec = Path("{{project_root}}/packaging/rpm/exwm-vr.spec").read_text()
+    start = spec.index(";;; exwm-vr-init.el")
+    end = spec.index("ELISP_EOF", start)
+    snippet = spec[start:end]
+    if "exwm-vr/core" in snippet:
+        raise SystemExit("default package init must not add lisp/core to load-path")
+    print("package_no_default_lisp_core=passed")
+    PY
+
+[group('test')]
+boot-without-emacs-smoke seconds="1":
+    "{{project_root}}/packaging/scripts/boot-without-emacs-smoke" "{{seconds}}"
+
+[group('test')]
 test-all: test test-compositor test-integration
 
 # ── lint ───────────────────────────────────────────────
@@ -76,8 +126,15 @@ lint-elisp:
 
 [group('lint')]
 lint-rust:
-    @echo "Linting Rust..."
-    cargo clippy --manifest-path "{{project_root}}/compositor/Cargo.toml" -- -D warnings
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Linting Rust..."
+    if [[ "$(uname -s)" = "Linux" ]]; then
+        cargo clippy --manifest-path "{{project_root}}/compositor/Cargo.toml" \
+            --features full-backend -- -D warnings
+    else
+        cargo clippy --manifest-path "{{project_root}}/compositor/Cargo.toml" -- -D warnings
+    fi
 
 [group('lint')]
 lint-all: lint-elisp lint-rust
@@ -159,6 +216,8 @@ vr-benchmark-gpu:
 # ── beyond / remote setup ─────────────────────────────
 
 setup_script := project_root + "/packaging/scripts/exwm-vr-setup"
+hmd_connector_script := project_root + "/packaging/scripts/exwm-vr-hmd-connector"
+kernel_dsc_truth_script := project_root + "/packaging/scripts/exwm-vr-kernel-dsc-truth"
 
 # Deploy the unified setup script to a remote host, then run a command.
 # Usage: just beyond-remote <host> <command>
@@ -166,17 +225,18 @@ setup_script := project_root + "/packaging/scripts/exwm-vr-setup"
 #   just beyond-remote honey verify      — check display, USB, permissions
 #   just beyond-remote honey beyond-status
 [group('vr')]
-beyond-remote host command:
+beyond-remote host *command:
     @echo "=== {{host}}: {{command}} ==="
-    scp -q "{{setup_script}}" "{{project_root}}/packaging/udev/99-exwm-vr.rules" "{{project_root}}/packaging/scripts/beyond-power-on" "{{project_root}}/packaging/systemd/exwm-vr-beyond-power.service" "{{project_root}}/packaging/sway/config" "{{project_root}}/packaging/sway/status.sh" "{{project_root}}/patches/wlroots-bigscreen-non-desktop.patch" "{{project_root}}/patches/amd-bsb-dsc-fix.patch" "{{project_root}}/patches/bigscreen-beyond-edid.patch" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup /tmp/beyond-power-on && mv -f /tmp/config /tmp/exwm-sway-config 2>/dev/null; mv -f /tmp/status.sh /tmp/exwm-sway-status.sh 2>/dev/null; /tmp/exwm-vr-setup {{command}}"
+    scp -q "{{setup_script}}" "{{hmd_connector_script}}" "{{project_root}}/packaging/udev/99-exwm-vr.rules" "{{project_root}}/packaging/scripts/beyond-power-on" "{{project_root}}/packaging/systemd/exwm-vr-beyond-power.service" "{{project_root}}/packaging/sway/config" "{{project_root}}/packaging/sway/status.sh" "{{project_root}}/patches/wlroots-bigscreen-non-desktop.patch" "{{project_root}}/patches/amd-bsb-dsc-fix.patch" "{{project_root}}/patches/bigscreen-beyond-edid.patch" jess@{{host}}:/tmp/
+    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup /tmp/exwm-vr-hmd-connector /tmp/beyond-power-on && mv -f /tmp/config /tmp/exwm-sway-config 2>/dev/null; mv -f /tmp/status.sh /tmp/exwm-sway-status.sh 2>/dev/null; /tmp/exwm-vr-setup {{command}}"
 
-# Same as beyond-remote but wraps in sudo (prompts for password).
+# Same as beyond-remote but wraps in SOPS-backed sudo on Honey.
 [group('vr')]
-beyond-remote-sudo host command:
+beyond-remote-sudo host *command:
     @echo "=== {{host}}: sudo {{command}} ==="
-    scp -q "{{setup_script}}" "{{project_root}}/packaging/udev/99-exwm-vr.rules" "{{project_root}}/packaging/scripts/beyond-power-on" "{{project_root}}/packaging/systemd/exwm-vr-beyond-power.service" "{{project_root}}/packaging/sway/config" "{{project_root}}/packaging/sway/status.sh" "{{project_root}}/patches/wlroots-bigscreen-non-desktop.patch" "{{project_root}}/patches/amd-bsb-dsc-fix.patch" "{{project_root}}/patches/bigscreen-beyond-edid.patch" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup /tmp/beyond-power-on && mv -f /tmp/config /tmp/exwm-sway-config 2>/dev/null; mv -f /tmp/status.sh /tmp/exwm-sway-status.sh 2>/dev/null; echo 'Running with sudo...' && sudo /tmp/exwm-vr-setup {{command}}"
+    scp -q "{{setup_script}}" "{{hmd_connector_script}}" "{{project_root}}/packaging/udev/99-exwm-vr.rules" "{{project_root}}/packaging/scripts/beyond-power-on" "{{project_root}}/packaging/systemd/exwm-vr-beyond-power.service" "{{project_root}}/packaging/sway/config" "{{project_root}}/packaging/sway/status.sh" "{{project_root}}/patches/wlroots-bigscreen-non-desktop.patch" "{{project_root}}/patches/amd-bsb-dsc-fix.patch" "{{project_root}}/patches/bigscreen-beyond-edid.patch" jess@{{host}}:/tmp/
+    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup /tmp/exwm-vr-hmd-connector /tmp/beyond-power-on && mv -f /tmp/config /tmp/exwm-sway-config 2>/dev/null; mv -f /tmp/status.sh /tmp/exwm-sway-status.sh 2>/dev/null"
+    just honey-sudo-run {{host}} -- "/tmp/exwm-vr-setup {{command}}"
 
 # Shorthand aliases for common operations
 [group('vr')]
@@ -192,6 +252,10 @@ beyond-hid-test host="honey":
     just beyond-remote {{host}} beyond-hid-test
 
 [group('vr')]
+beyond-hmd-connector host="honey":
+    just beyond-remote {{host}} beyond-hmd-connector
+
+[group('vr')]
 beyond-setup host="honey":
     @echo "Full setup on {{host}} (sudo required)..."
     just beyond-remote-sudo {{host}} full-setup
@@ -205,6 +269,11 @@ beyond-gpu-tools host="honey":
 beyond-display-init host="honey":
     @echo "Beyond display init on {{host}} (sudo required)..."
     just beyond-remote-sudo {{host}} beyond-display-init
+
+[group('vr')]
+beyond-drm-dump host="honey" connector="auto":
+    @echo "Beyond DRM debugfs dump on {{host}} (sudo read-only)..."
+    just beyond-remote-sudo {{host}} beyond-drm-dump {{connector}}
 
 [group('vr')]
 beyond-power-on host="honey" *args="":
@@ -257,7 +326,8 @@ beyond-kernel-dsc-fix host="honey":
 beyond-kernel-build host="honey" *args="":
     @echo "Building XR kernel on {{host}} (sudo required, takes ~30min)..."
     scp -q "{{setup_script}}" "{{project_root}}/patches/bigscreen-beyond-edid.patch" "{{project_root}}/patches/0007-vesa-dsc-bpp.patch" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup && sudo /tmp/exwm-vr-setup kernel-build {{args}}"
+    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-setup"
+    just honey-sudo-run {{host}} -- "/tmp/exwm-vr-setup kernel-build {{args}}"
 
 # ── deploy ────────────────────────────────────────────
 
@@ -338,7 +408,7 @@ beyond-kernel-install host tag variant="generic":
     gh release download "{{tag}}" -R "{{linux_xr_repo}}" \
         -p "${PATTERN}" -D /tmp/kernel-xr-rpms/ --clobber
     scp /tmp/kernel-xr-rpms/*.rpm jess@{{host}}:/tmp/
-    ssh jess@{{host}} "echo 'tinyland' | sudo -S bash -c '
+    ssh jess@{{host}} "f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password}; cat \"\$f\" | sudo -S -p \"\" bash -c '
     set -euo pipefail
     echo \">>> Installing RPM...\"
     dnf install -y /tmp/kernel-xr*.x86_64.rpm 2>&1 | tail -5
@@ -394,24 +464,20 @@ beyond-kernel-verify host="honey":
     ssh jess@{{host}} "uname -r && zcat /proc/config.gz 2>/dev/null | grep -E 'HZ=|PREEMPT_RT|DRM_AMD_DC_DSC|USB_HIDDEV' || grep -E 'HZ=|PREEMPT_RT|DRM_AMD_DC_DSC|USB_HIDDEV' /boot/config-\$(uname -r)"
 
 # Dump DSC PPS from debugfs and verify QP/RC fix is active.
-# Requires Beyond to be connected and display active on DP-2.
+# Resolves the live HMD connector by non_desktop/BIG EDID unless overridden.
 [group('vr')]
-beyond-kernel-pps host="honey" connector="DP-2":
+beyond-kernel-pps host="honey" connector="auto":
+    just honey-kernel-dsc-truth {{host}} {{connector}}
+
+# Run the read-only kernel/driver DSC truth helper through Honey's SOPS-backed sudo path.
+[group('vr')]
+honey-kernel-dsc-truth host="honey" connector="auto":
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "=== DSC PPS dump from {{host}} ({{connector}}) ==="
-    PPS=$(ssh jess@{{host}} "sudo cat /sys/kernel/debug/dri/1/{{connector}}/dsc_pic_parameter_set 2>/dev/null || echo 'NOT_FOUND'")
-    if [ "$PPS" = "NOT_FOUND" ]; then
-        echo "PPS not available — is DSC active on {{connector}}?"
-        echo "Try: ssh jess@{{host}} 'ls /sys/kernel/debug/dri/*/'"
-        exit 1
-    fi
-    echo "$PPS"
-    echo ""
-    echo "=== QP/RC fix verification ==="
-    echo "Check rc_range_params bytes 77-87 against expected patched values:"
-    echo "  PPS[77]=0x83 PPS[79]=0xC5 PPS[80]=0xA3 PPS[81]=0x05"
-    echo "  PPS[82]=0xA3 PPS[83]=0x45 PPS[85]=0x47 PPS[87]=0xCD"
+    echo "=== Kernel/DSC truth on {{host}} ({{connector}}) ==="
+    scp -q "{{kernel_dsc_truth_script}}" jess@{{host}}:/tmp/exwm-vr-kernel-dsc-truth
+    ssh jess@{{host}} "chmod +x /tmp/exwm-vr-kernel-dsc-truth"
+    just honey-sudo-run {{host}} -- "/tmp/exwm-vr-kernel-dsc-truth --connector {{connector}}"
 
 # ── dev ────────────────────────────────────────────────
 
@@ -641,6 +707,65 @@ honey-run host="honey" *args="":
     cmd="$(printf '%s' "$1" | base64 --decode)"
     exec nix develop --command bash -lc "$cmd"
     REMOTE
+
+[group('ci')]
+native-authority-proof mode="read-only" launch_target="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=()
+    if [[ "{{mode}}" = "mutating" ]]; then
+        args+=(--mutating)
+    fi
+    if [[ -n "{{launch_target}}" ]]; then
+        args+=(--launch-target "{{launch_target}}")
+    fi
+    "{{project_root}}/packaging/scripts/xoxdwm-native-authority-proof" "${args[@]}"
+
+[group('ci')]
+remote-native-authority-proof host="honey" mode="read-only" launch_target="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Native authority proof on {{host}} ({{mode}}; no reboot) ==="
+    cmd='if command -v /usr/libexec/exwm-vr/native-authority-proof >/dev/null 2>&1; then /usr/libexec/exwm-vr/native-authority-proof; else packaging/scripts/xoxdwm-native-authority-proof; fi'
+    if [[ "{{mode}}" = "mutating" ]]; then
+        cmd="$cmd --mutating"
+    fi
+    if [[ -n "{{launch_target}}" ]]; then
+        cmd="$cmd --launch-target {{launch_target}}"
+    fi
+    just honey-run {{host}} -- "$cmd"
+
+[group('ci')]
+honey-sudo-run host="honey" *args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cmd="$(cat <<'EOF'
+    {{args}}
+    EOF
+    )"
+    cmd="${cmd#-- }"
+    cmd="${cmd#--}"
+    if [[ -z "${cmd}" ]]; then
+        echo "Usage: just honey-sudo-run {{host}} -- <command...>"
+        exit 1
+    fi
+    cmd_b64="$(printf '%s' "${cmd}" | base64 | tr -d '\n')"
+    ssh jess@{{host}} bash -s -- "${cmd_b64}" <<'REMOTE'
+    set -euo pipefail
+    cd "{{remote_repo_path}}"
+    export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    become_file="${BECOME_PASSWORD_FILE:-$HOME/.config/sops-nix/secrets/become/password}"
+    if [[ ! -r "${become_file}" ]]; then
+        echo "ERROR: Honey SOPS become file is not readable: ${become_file}" >&2
+        exit 77
+    fi
+    cmd="$(printf '%s' "$1" | base64 --decode)"
+    cat "${become_file}" | sudo -S -p "" bash -lc "$cmd"
+    REMOTE
+
+[group('ci')]
+honey-sudo-check host="honey":
+    just honey-sudo-run {{host}} -- 'true && echo sudo_ok'
 
 [group('ci')]
 honey-proof-env host="honey":
@@ -989,7 +1114,7 @@ bios-create-freedos-usb-remote host dev:
     # Copy BIOS exe to remote
     scp "{{bios_dir}}/{{bios_exe}}" jess@{{host}}:/tmp/
 
-    ssh jess@{{host}} "echo 'tinyland' | sudo -S bash -c '
+    ssh jess@{{host}} "f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password}; cat \"\$f\" | sudo -S -p \"\" bash -c '
     set -euo pipefail
     FDOS_URL=\"https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.3/official/FD13-FloppyEdition.zip\"
 
@@ -1076,7 +1201,7 @@ bios-verify host="honey":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "=== BIOS version on {{host}} ==="
-    ssh jess@{{host}} "sudo dmidecode -t bios | grep -E 'Vendor|Version|Release|Revision|Date'"
+    just honey-sudo-run {{host}} -- "dmidecode -t bios | grep -E 'Vendor|Version|Release|Revision|Date'"
 
 # Deploy tuned profile for BCI/VR workloads to remote host.
 # Prefer the Dell-owned T7810 profile when the sibling repo is present.
@@ -1095,7 +1220,7 @@ bios-tuned-deploy host="honey":
         echo "=== Deploying legacy XoxdWM ${profile_name} tuned profile to {{host}} ==="
     fi
     scp -r "${profile_dir}" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "echo 'tinyland' | sudo -S bash -c 'cp -r /tmp/${profile_name} /etc/tuned/ && tuned-adm profile ${profile_name} && echo Done: && tuned-adm active'"
+    ssh jess@{{host}} "f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password}; cat \"\$f\" | sudo -S -p \"\" bash -c 'cp -r /tmp/${profile_name} /etc/tuned/ && tuned-adm profile ${profile_name} && echo Done: && tuned-adm active'"
 
 # Run SMI validation on remote host (characterize hardware latency).
 # Prefer the Dell-owned validator when the sibling repo is present.
@@ -1113,7 +1238,7 @@ smi-validate host="honey" *args="":
         echo "Using legacy XoxDWM SMI validator."
     fi
     scp "${validator}" jess@{{host}}:/tmp/smi-validate
-    ssh jess@{{host}} "chmod +x /tmp/smi-validate && echo 'tinyland' | sudo -S /tmp/smi-validate {{args}}"
+    ssh jess@{{host}} "chmod +x /tmp/smi-validate && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/smi-validate {{args}}"
 
 # ── rollout ─────────────────────────────────────────
 
@@ -1171,7 +1296,7 @@ rollout-preflight host="honey":
     echo "${P}HAS_LMSENSORS='$(command -v sensors &>/dev/null && echo yes || echo no)'"
     echo "${P}GRUB_CMDLINE='$(grep GRUB_CMDLINE_LINUX /etc/default/grub 2>/dev/null | head -1)'"
     REMOTE
-    REMOTE_STATE=$(ssh jess@{{host}} "chmod +x /tmp/_preflight.sh && echo 'tinyland' | sudo -S /tmp/_preflight.sh 2>/dev/null; rm -f /tmp/_preflight.sh")
+    REMOTE_STATE=$(ssh jess@{{host}} "chmod +x /tmp/_preflight.sh && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/_preflight.sh 2>/dev/null; rm -f /tmp/_preflight.sh")
 
     # Parse remote state — only eval lines with our prefix (ignores MOTD, sudo noise)
     eval "$(echo "$REMOTE_STATE" | grep '^__PF__' | sed 's/^__PF__//')"
@@ -1309,7 +1434,7 @@ storage-preflight host="honey":
     set -euo pipefail
     echo "=== Storage pre-flight on {{host}} ==="
     scp "{{project_root}}/packaging/scripts/honey-storage-migrate" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/honey-storage-migrate && echo 'tinyland' | sudo -S /tmp/honey-storage-migrate phase0"
+    ssh jess@{{host}} "chmod +x /tmp/honey-storage-migrate && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/honey-storage-migrate phase0"
 
 # Run storage migration phase (pvmove root to NVMe, etc).
 # Usage: just storage-migrate honey phase1
@@ -1324,7 +1449,7 @@ storage-migrate host="honey" phase="phase0" *args="":
     set -euo pipefail
     echo "=== Storage migration {{phase}} on {{host}} ==="
     scp "{{project_root}}/packaging/scripts/honey-storage-migrate" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/honey-storage-migrate && echo 'tinyland' | sudo -S /tmp/honey-storage-migrate {{phase}} {{args}}"
+    ssh jess@{{host}} "chmod +x /tmp/honey-storage-migrate && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/honey-storage-migrate {{phase}} {{args}}"
 
 # Show current storage layout on remote host.
 [group('storage')]
@@ -1332,7 +1457,7 @@ storage-status host="honey":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "=== Storage status on {{host}} ==="
-    ssh jess@{{host}} "echo '── PVs ──' && sudo pvs 2>/dev/null; echo '── VGs ──' && sudo vgs 2>/dev/null; echo '── LVs ──' && sudo lvs 2>/dev/null; echo '── df ──' && df -h / /boot /home /data /archive 2>/dev/null; echo '── lsblk ──' && lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT"
+    just honey-sudo-run {{host}} -- 'echo "── PVs ──" && pvs 2>/dev/null; echo "── VGs ──" && vgs 2>/dev/null; echo "── LVs ──" && lvs 2>/dev/null; echo "── df ──" && df -h / /boot /home /data /archive 2>/dev/null; echo "── lsblk ──" && lsblk -o NAME,SIZE,TYPE,FSTYPE,MOUNTPOINT'
 
 # ── boot (Dhall IaC) ────────────────────────────────
 
@@ -1414,7 +1539,7 @@ boot-apply host="honey" config="xr" mode="--dry-run":
     set -euo pipefail
     echo "=== Boot apply ({{mode}}) {{config}} on {{host}} ==="
     scp -r "{{project_root}}/packaging/dhall" "{{project_root}}/packaging/scripts/boot-apply" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/boot-apply && echo 'tinyland' | sudo -S /tmp/boot-apply {{mode}} {{config}}"
+    ssh jess@{{host}} "chmod +x /tmp/boot-apply && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/boot-apply {{mode}} {{config}}"
 
 # Verify boot configuration on remote host.
 [group('boot')]
@@ -1422,7 +1547,7 @@ boot-verify host="honey":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "=== Boot verification on {{host}} ==="
-    ssh jess@{{host}} "echo '── Kernel ──' && uname -r; echo '── Default ──' && sudo grubby --default-kernel; echo '── BLS Entries ──' && ls -la /boot/loader/entries/; echo '── Current cmdline ──' && cat /proc/cmdline; echo '── GRUB defaults ──' && cat /etc/default/grub"
+    just honey-sudo-run {{host}} -- 'echo "── Kernel ──" && uname -r; echo "── Default ──" && grubby --default-kernel; echo "── BLS Entries ──" && ls -la /boot/loader/entries/; echo "── Current cmdline ──" && cat /proc/cmdline; echo "── GRUB defaults ──" && cat /etc/default/grub'
 
 # Test a kernel with grub2-reboot (one-shot: auto-reverts to saved default on next reboot).
 # Usage: just boot-test-kernel honey /boot/vmlinuz-6.19.5-5.xr.el10
@@ -1437,11 +1562,11 @@ boot-test-kernel host="honey" kernel="":
         echo "This uses grub2-reboot for a ONE-SHOT boot. If the kernel fails,"
         echo "the next power cycle auto-boots the saved default (ELRepo)."
         echo ""
-        ssh jess@{{host}} "echo 'tinyland' | sudo -S grubby --info=ALL 2>/dev/null | grep -E '^(index|kernel|title)='"
+        ssh jess@{{host}} "f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password}; cat \"\$f\" | sudo -S -p \"\" grubby --info=ALL 2>/dev/null | grep -E '^(index|kernel|title)='"
         exit 1
     fi
     echo "=== One-shot kernel test on {{host}} ==="
-    ssh jess@{{host}} "echo 'tinyland' | sudo -S bash -c '
+    ssh jess@{{host}} "f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password}; cat \"\$f\" | sudo -S -p \"\" bash -c '
         SAVED=\$(grubby --default-kernel)
         echo \"  Saved default: \${SAVED}\"
         echo \"  Testing: {{kernel}}\"
@@ -1501,4 +1626,4 @@ gpu-dell-quiet host="honey":
     #!/usr/bin/env bash
     set -euo pipefail
     scp "{{project_root}}/packaging/scripts/gpu-monitor" jess@{{host}}:/tmp/
-    ssh jess@{{host}} "chmod +x /tmp/gpu-monitor && echo 'tinyland' | sudo -S /tmp/gpu-monitor dell-quiet"
+    ssh jess@{{host}} "chmod +x /tmp/gpu-monitor && f=\${BECOME_PASSWORD_FILE:-\$HOME/.config/sops-nix/secrets/become/password} && cat \"\$f\" | sudo -S -p \"\" /tmp/gpu-monitor dell-quiet"

--- a/packaging/rpm/exwm-vr.spec
+++ b/packaging/rpm/exwm-vr.spec
@@ -625,6 +625,8 @@ fi
 %{_datadir}/%{project_name}/exwm-vr-session
 %{_datadir}/%{project_name}/exwm-vr-session-init.el
 %{_datadir}/xdg-desktop-portal/exwm-vr-portals.conf
+%dir %{_libexecdir}/%{project_name}
+%{_libexecdir}/%{project_name}/native-authority-proof
 %dir %{_localstatedir}/lib/%{project_name}
 %endif
 

--- a/packaging/rpm/exwm-vr.spec
+++ b/packaging/rpm/exwm-vr.spec
@@ -306,7 +306,7 @@ cargo build --release --no-default-features \
 # Native Rocky RPMs currently build the host-runnable compositor without the
 # `vr` feature; the full VR lane still depends on libuvc packaging that is not
 # yet proven on named Rocky hosts.
-cargo build --release \
+cargo build --release --features full-backend \
     --jobs %{_smp_build_ncpus} \
     %{?_cargo_extra_args}
 # Save the native compositor binary before the headless build overwrites
@@ -394,7 +394,8 @@ install -d %{buildroot}%{_datadir}/emacs/site-lisp/site-start.d
 cat > %{buildroot}%{_datadir}/emacs/site-lisp/site-start.d/%{project_name}-init.el << 'ELISP_EOF'
 ;;; exwm-vr-init.el --- Auto-load setup for EXWM-VR  -*- lexical-binding: t -*-
 (let ((base (file-name-directory load-file-name)))
-  (add-to-list 'load-path (expand-file-name "../exwm-vr/core" base))
+  ;; lisp/core is packaged as a compatibility/archive surface, but default
+  ;; runtime WM authority is native Rust plus lisp/vr app-layer clients.
   (add-to-list 'load-path (expand-file-name "../exwm-vr/vr" base))
   (add-to-list 'load-path (expand-file-name "../exwm-vr/ext" base)))
 ;;; exwm-vr-init.el ends here
@@ -411,6 +412,10 @@ install -Dpm 0755 packaging/scripts/exwm-vr-monado-launch \
     %{buildroot}%{_libexecdir}/%{project_name}/monado-launch
 install -Dpm 0755 packaging/scripts/exwm-vr-openxr-smoke \
     %{buildroot}%{_libexecdir}/%{project_name}/openxr-smoke
+install -Dpm 0755 packaging/scripts/exwm-vr-hmd-connector \
+    %{buildroot}%{_libexecdir}/%{project_name}/hmd-connector
+install -Dpm 0755 packaging/scripts/exwm-vr-kernel-dsc-truth \
+    %{buildroot}%{_libexecdir}/%{project_name}/kernel-dsc-truth
 %endif
 install -Dpm 0644 %{SOURCE22} \
     %{buildroot}%{_userunitdir}/exwm-vr-emacs.service
@@ -420,6 +425,8 @@ install -Dpm 0644 %{SOURCE23} \
 %endif
 install -Dpm 0644 %{SOURCE24} \
     %{buildroot}%{_userunitdir}/exwm-vr.target
+install -Dpm 0755 packaging/scripts/xoxdwm-native-authority-proof \
+    %{buildroot}%{_libexecdir}/%{project_name}/native-authority-proof
 %endif
 
 # --- Monado runtime integration (skip on s390x -- no HMD hardware) ---
@@ -499,7 +506,7 @@ cargo test --release --no-default-features \
     %{?_cargo_extra_args} || \
     echo "WARN: Rust tests (headless) -- skipped on mock build"
 %else
-cargo test --release %{?_cargo_extra_args} || \
+cargo test --release --features full-backend %{?_cargo_extra_args} || \
     echo "WARN: Rust tests require Linux DRM/Wayland -- skipped on mock build"
 %endif
 popd
@@ -638,6 +645,8 @@ fi
 %{_userunitdir}/exwm-vr-monado.service
 %{_libexecdir}/%{project_name}/monado-launch
 %{_libexecdir}/%{project_name}/openxr-smoke
+%{_libexecdir}/%{project_name}/hmd-connector
+%{_libexecdir}/%{project_name}/kernel-dsc-truth
 %{_udevrulesdir}/99-exwm-vr.rules
 %dir %{_sysconfdir}/xdg/openxr
 %dir %{_sysconfdir}/xdg/openxr/1

--- a/packaging/scripts/boot-without-emacs-smoke
+++ b/packaging/scripts/boot-without-emacs-smoke
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+seconds="${1:-1}"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+runtime_dir="$(mktemp -d)"
+trap 'rm -rf "${runtime_dir}"' EXIT
+
+export XDG_RUNTIME_DIR="${runtime_dir}"
+socket="${runtime_dir}/ewwm-ipc.sock"
+
+echo "smoke=boot_without_emacs"
+echo "seconds=${seconds}"
+echo "runtime_dir=${runtime_dir}"
+echo "socket=${socket}"
+
+if pgrep -af "emacs.*exwm-vr\\|emacs.*ewwm" >/dev/null 2>&1; then
+    echo "emacs_path=present_before_smoke"
+else
+    echo "emacs_path=absent_before_smoke"
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    cargo check --manifest-path "${root}/compositor/Cargo.toml" \
+        --bin ewwm-compositor --no-default-features \
+        >/tmp/xoxdwm-boot-without-emacs.log 2>&1
+    echo "boot_without_emacs=skipped_non_linux"
+    echo "reason=runtime_smoke_requires_linux_compositor_backend"
+    exit 0
+fi
+
+cargo build --manifest-path "${root}/compositor/Cargo.toml" \
+    --bin ewwm-compositor --no-default-features \
+    >/tmp/xoxdwm-boot-without-emacs.log 2>&1
+
+timeout "$((seconds + 8))" \
+    "${root}/compositor/target/debug/ewwm-compositor" \
+        --backend headless \
+        --headless-exit-after "${seconds}" \
+        --ipc-socket "${socket}" \
+    >>/tmp/xoxdwm-boot-without-emacs.log 2>&1
+
+if grep -Eqi 'emacs|lisp/core|EXWM' /tmp/xoxdwm-boot-without-emacs.log; then
+    echo "emacs_path=mentioned_in_compositor_log"
+    sed -n '1,120p' /tmp/xoxdwm-boot-without-emacs.log
+    exit 1
+fi
+
+echo "boot_without_emacs=passed"

--- a/packaging/scripts/boot-without-emacs-smoke
+++ b/packaging/scripts/boot-without-emacs-smoke
@@ -5,6 +5,8 @@ seconds="${1:-1}"
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 runtime_dir="$(mktemp -d)"
 trap 'rm -rf "${runtime_dir}"' EXIT
+build_log="/tmp/xoxdwm-boot-without-emacs-build.log"
+runtime_log="/tmp/xoxdwm-boot-without-emacs-runtime.log"
 
 export XDG_RUNTIME_DIR="${runtime_dir}"
 socket="${runtime_dir}/ewwm-ipc.sock"
@@ -23,7 +25,7 @@ fi
 if [[ "$(uname -s)" != "Linux" ]]; then
     cargo check --manifest-path "${root}/compositor/Cargo.toml" \
         --bin ewwm-compositor --no-default-features \
-        >/tmp/xoxdwm-boot-without-emacs.log 2>&1
+        >"${build_log}" 2>&1
     echo "boot_without_emacs=skipped_non_linux"
     echo "reason=runtime_smoke_requires_linux_compositor_backend"
     exit 0
@@ -31,18 +33,18 @@ fi
 
 cargo build --manifest-path "${root}/compositor/Cargo.toml" \
     --bin ewwm-compositor --no-default-features \
-    >/tmp/xoxdwm-boot-without-emacs.log 2>&1
+    >"${build_log}" 2>&1
 
 timeout "$((seconds + 8))" \
     "${root}/compositor/target/debug/ewwm-compositor" \
         --backend headless \
         --headless-exit-after "${seconds}" \
         --ipc-socket "${socket}" \
-    >>/tmp/xoxdwm-boot-without-emacs.log 2>&1
+    >"${runtime_log}" 2>&1
 
-if grep -Eqi 'emacs|lisp/core|EXWM' /tmp/xoxdwm-boot-without-emacs.log; then
+if grep -Eqi 'emacs|lisp/core' "${runtime_log}"; then
     echo "emacs_path=mentioned_in_compositor_log"
-    sed -n '1,120p' /tmp/xoxdwm-boot-without-emacs.log
+    sed -n '1,120p' "${runtime_log}"
     exit 1
 fi
 

--- a/packaging/scripts/xoxdwm-native-authority-proof
+++ b/packaging/scripts/xoxdwm-native-authority-proof
@@ -63,9 +63,7 @@ import sys
 
 path, mode, launch_target = sys.argv[1], sys.argv[2], sys.argv[3]
 
-def send(sock, message):
-    payload = message.encode("utf-8")
-    sock.sendall(struct.pack(">I", len(payload)) + payload)
+def read_frame(sock):
     header = sock.recv(4)
     if len(header) != 4:
         raise SystemExit("short IPC response header")
@@ -78,17 +76,27 @@ def send(sock, message):
         data += chunk
     return data.decode("utf-8", "replace")
 
+def send(sock, message, expected_id):
+    payload = message.encode("utf-8")
+    sock.sendall(struct.pack(">I", len(payload)) + payload)
+    marker = f":id {expected_id}"
+    while True:
+        response = read_frame(sock)
+        if marker in response:
+            return response
+        print("event=" + response)
+
 with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
     sock.connect(path)
-    print("hello=" + send(sock, '(:type :hello :id 1 :version 1 :client "native-authority-proof")'))
-    print("workspace_list=" + send(sock, "(:type :workspace-list :id 2)"))
-    print("surface_list=" + send(sock, "(:type :surface-list :id 3)"))
-    print("focused_surface=" + send(sock, "(:type :focused-surface :id 4)"))
+    print("hello=" + send(sock, '(:type :hello :id 1 :version 1 :client "native-authority-proof")', 1))
+    print("workspace_list=" + send(sock, "(:type :workspace-list :id 2)", 2))
+    print("surface_list=" + send(sock, "(:type :surface-list :id 3)", 3))
+    print("focused_surface=" + send(sock, "(:type :focused-surface :id 4)", 4))
     if mode == "mutating":
-        print("layout_cycle=" + send(sock, "(:type :layout-cycle :id 5)"))
-        print("workspace_switch=" + send(sock, "(:type :workspace-switch :id 6 :workspace 0)"))
+        print("layout_cycle=" + send(sock, "(:type :layout-cycle :id 5)", 5))
+        print("workspace_switch=" + send(sock, "(:type :workspace-switch :id 6 :workspace 0)", 6))
         if launch_target:
-            print("app_launch=" + send(sock, f'(:type :app-launch :id 7 :target "{launch_target}")'))
+            print("app_launch=" + send(sock, f'(:type :app-launch :id 7 :target "{launch_target}")', 7))
 PY
 
 echo "native_authority=checked"

--- a/packaging/scripts/xoxdwm-native-authority-proof
+++ b/packaging/scripts/xoxdwm-native-authority-proof
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+socket="${EWWM_IPC_SOCKET:-${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ewwm-ipc.sock}"
+mode="read-only"
+launch_target=""
+
+while (($#)); do
+    case "$1" in
+        --socket)
+            socket="$2"
+            shift 2
+            ;;
+        --mutating)
+            mode="mutating"
+            shift
+            ;;
+        --launch-target)
+            launch_target="$2"
+            mode="mutating"
+            shift 2
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: xoxdwm-native-authority-proof [--socket PATH] [--mutating] [--launch-target NAME]
+
+Checks native XoxdWM IPC authority without making Emacs the WM authority path.
+Read-only mode queries state only. Mutating mode exercises layout/workspace IPC
+and optional configured app launch target.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+echo "proof=native_authority"
+echo "mode=${mode}"
+echo "host=$(hostname 2>/dev/null || echo unknown)"
+echo "uid=$(id -u)"
+echo "socket=${socket}"
+echo "emacs_service=$(systemctl --user is-active exwm-vr-emacs.service 2>/dev/null || true)"
+echo "compositor_service=$(systemctl --user is-active exwm-vr-compositor.service 2>/dev/null || true)"
+if systemctl is-active rke2-server >/dev/null 2>&1; then
+    echo "rke2=active"
+else
+    echo "rke2=$(systemctl is-active rke2-server 2>/dev/null || true)"
+fi
+
+if [[ ! -S "${socket}" ]]; then
+    echo "native_authority=failed"
+    echo "reason=ipc_socket_missing"
+    exit 1
+fi
+
+python3 - "$socket" "$mode" "$launch_target" <<'PY'
+import socket
+import struct
+import sys
+
+path, mode, launch_target = sys.argv[1], sys.argv[2], sys.argv[3]
+
+def send(sock, message):
+    payload = message.encode("utf-8")
+    sock.sendall(struct.pack(">I", len(payload)) + payload)
+    header = sock.recv(4)
+    if len(header) != 4:
+        raise SystemExit("short IPC response header")
+    size = struct.unpack(">I", header)[0]
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise SystemExit("short IPC response payload")
+        data += chunk
+    return data.decode("utf-8", "replace")
+
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+    sock.connect(path)
+    print("hello=" + send(sock, '(:type :hello :id 1 :version 1 :client "native-authority-proof")'))
+    print("workspace_list=" + send(sock, "(:type :workspace-list :id 2)"))
+    print("surface_list=" + send(sock, "(:type :surface-list :id 3)"))
+    print("focused_surface=" + send(sock, "(:type :focused-surface :id 4)"))
+    if mode == "mutating":
+        print("layout_cycle=" + send(sock, "(:type :layout-cycle :id 5)"))
+        print("workspace_switch=" + send(sock, "(:type :workspace-switch :id 6 :workspace 0)"))
+        if launch_target:
+            print("app_launch=" + send(sock, f'(:type :app-launch :id 7 :target "{launch_target}")'))
+PY
+
+echo "native_authority=checked"

--- a/packaging/sway/config
+++ b/packaging/sway/config
@@ -6,16 +6,17 @@
 #
 # Architecture:
 #   Sway (host compositor)
-#   ├── DP-1: Desktop monitor (Dell S2721QS, 3840x2160)
+#   ├── desktop monitor
 #   │   └── Emacs, terminals, Steam, browsers
-#   └── DP-2: Bigscreen Beyond (3840x1920, non-desktop)
+#   └── Bigscreen Beyond DisplayPort (non-desktop or resolver-selected)
 #       └── DRM-leased to Monado → OpenXR → SteamVR
 #
 # DRM Lease flow:
-#   1. Kernel marks DP-2 as non_desktop (via EDID quirk or udev rule)
+#   1. Kernel marks the headset connector as non_desktop, or
+#      exwm-vr-hmd-connector resolves it by BIG EDID / explicit override
 #   2. Sway detects non_desktop=1, excludes from desktop layout
-#   3. Sway offers DP-2 via wlr-drm-lease-v1 protocol
-#   4. Monado (or SteamVR) requests lease of DP-2
+#   3. Sway offers the headset connector via wlr-drm-lease-v1 protocol
+#   4. Monado (or SteamVR) requests lease of that connector
 #   5. Sway grants lease, Monado gets exclusive DRM access
 #
 # Install: ~/.config/sway/config
@@ -28,14 +29,12 @@ set $menu dmenu-wl_run
 
 # ── Outputs ───────────────────────────────────────────────
 
-# Desktop monitor (adjust connector name to match your hardware).
-# Use `swaymsg -t get_outputs` to list available outputs.
-output DP-1 resolution 3840x2160 position 0,0
+# Desktop monitor: let Sway pick the connected management display by default.
+# Use host-local config for fixed monitor geometry.
 
-# VR headset: explicitly disable as desktop output.
-# Sway should auto-detect non_desktop connectors, but this is a safety net.
-# The connector remains available for DRM lease to Monado/SteamVR.
-output DP-2 disable
+# VR headset: disable the resolver-selected connector as a desktop output.
+# If the kernel already exposes non_desktop=1, Sway should omit it anyway.
+exec_always sh -lc 'resolver=/usr/libexec/exwm-vr/hmd-connector; [ -x "$resolver" ] || resolver=exwm-vr-hmd-connector; hmd="$($resolver 2>/dev/null || true)"; [ -n "$hmd" ] && swaymsg output "$hmd" disable >/dev/null 2>&1 || true'
 
 # ── Input ─────────────────────────────────────────────────
 
@@ -134,7 +133,7 @@ exec_always export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
 # Monado / OpenXR
 # Temporary Wayland window fallback; not true DRM lease direct mode.
 exec_always export XRT_COMPOSITOR_FORCE_WAYLAND=1
-exec_always export XRT_COMPOSITOR_WAYLAND_CONNECTOR=DP-2
+exec_always sh -lc 'resolver=/usr/libexec/exwm-vr/hmd-connector; [ -x "$resolver" ] || resolver=exwm-vr-hmd-connector; hmd="$($resolver 2>/dev/null || true)"; [ -n "$hmd" ] && systemctl --user set-environment XRT_COMPOSITOR_WAYLAND_CONNECTOR="$hmd" EWWM_DRM_LEASE_CONNECTORS="$hmd" >/dev/null 2>&1 || true'
 
 # Beyond HMD — expose hidraw to Proton for Bigscreen companion app
 exec_always export PROTON_ENABLE_HIDRAW=0x35BD/0x0101

--- a/packaging/sway/status.sh
+++ b/packaging/sway/status.sh
@@ -2,7 +2,20 @@
 # Sway status bar for VR development hosts.
 # Shows date/time and HMD connector status.
 while :; do
-    hmd=$(cat /sys/class/drm/card0-DP-2/status 2>/dev/null || echo "N/A")
-    echo "$(date +'%Y-%m-%d %H:%M') | HMD:${hmd}"
+    resolver="/usr/libexec/exwm-vr/hmd-connector"
+    [ -x "$resolver" ] || resolver="exwm-vr-hmd-connector"
+    connector="$($resolver 2>/dev/null || true)"
+    if [ -n "$connector" ]; then
+        path=""
+        for candidate in /sys/class/drm/card*-"$connector"; do
+            [ -e "$candidate" ] || continue
+            path="$candidate"
+            break
+        done
+        hmd=$(cat "$path/status" 2>/dev/null || echo "unknown")
+        echo "$(date +'%Y-%m-%d %H:%M') | HMD:${connector}:${hmd}"
+    else
+        echo "$(date +'%Y-%m-%d %H:%M') | HMD:N/A"
+    fi
     sleep 5
 done

--- a/test/native-authority-test.el
+++ b/test/native-authority-test.el
@@ -1,0 +1,125 @@
+;;; native-authority-test.el --- Native XoxdWM authority guardrails -*- lexical-binding: t; -*-
+
+;;; Code:
+
+(require 'ert)
+
+(defconst native-authority-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name)))))
+
+(defun native-authority-test--read-file (relative)
+  "Return project file RELATIVE as a string."
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name relative native-authority-test--root))
+    (buffer-string)))
+
+(ert-deftest native-authority/config-owns-workspace-layout-and-launch-policy ()
+  "Native config should own core WM policy inputs."
+  (let ((config (native-authority-test--read-file "compositor/src/config.rs")))
+    (dolist (needle '("workspace_count"
+                      "active_workspace"
+                      "layout_mode"
+                      "key_actions"
+                      "app_launch_commands"
+                      "autostart_enabled"
+                      "session_lock_command"
+                      "session_idle_command"))
+      (should (string-match-p needle config)))))
+
+(ert-deftest native-authority/state-has-native-layout-and-visibility-reflow ()
+  "Rust state should apply workspace visibility and layout reflow."
+  (let ((state (native-authority-test--read-file "compositor/src/state.rs")))
+    (dolist (needle '("fn layout_rects"
+                      "reflow_native_layout"
+                      "apply_workspace_visibility"
+                      "set_surface_geometry"
+                      "current_layout"
+                      "visible: bool"))
+      (should (string-match-p needle state)))
+    (should-not (string-match-p "layout set (Emacs-driven)" state))))
+
+(ert-deftest native-authority/ipc-exposes-native-policy-surface ()
+  "IPC should expose native policy commands instead of Lisp-only authority."
+  (let ((dispatch (native-authority-test--read-file "compositor/src/ipc/dispatch.rs")))
+    (dolist (cmd '("\"app-launch\""
+                   "\"app-launch-list\""
+                   "\"config-reload\""
+                   "\"reload-config\""
+                   "\"autostart-list\""
+                   "\"autostart-run\""
+                   "\"session-status\""
+                   "\"session-lock\""
+                   "\"session-logout\""
+                   "\"session-idle-status\""
+                   "\"session-idle-start\""
+                   "\"session-idle-stop\""))
+      (should (string-match-p cmd dispatch)))
+    (should (string-match-p "state\\.set_native_layout" dispatch))
+    (should (string-match-p "state\\.reflow_native_layout" dispatch))))
+
+(ert-deftest native-authority/native-key-actions-run-before-emacs-grabs ()
+  "Keyboard input should check native key actions before IPC key grabs."
+  (let ((input (native-authority-test--read-file "compositor/src/input.rs")))
+    (should (string-match-p "handle_native_key_action" input))
+    (should (< (string-match "handle_native_key_action" input)
+               (string-match "grabbed_keys\\.contains" input)))))
+
+(ert-deftest native-authority/lisp-helpers-are-connected-ipc-clients ()
+  "Bundled Lisp helpers should request native IPC when connected."
+  (let ((input (native-authority-test--read-file "lisp/vr/ewwm-input.el"))
+        (layout (native-authority-test--read-file "lisp/vr/ewwm-layout.el"))
+        (session (native-authority-test--read-file "lisp/vr/ewwm-session.el"))
+        (launch (native-authority-test--read-file "lisp/vr/ewwm-launch.el")))
+    (dolist (needle '(":workspace-switch"
+                      ":workspace-move-surface"
+                      ":layout-cycle"
+                      ":config-reload"))
+      (should (string-match-p needle input)))
+    (should (string-match-p ":layout-set" layout))
+    (should (string-match-p ":session-lock" session))
+    (should (string-match-p ":session-logout" session))
+    (should (string-match-p ":session-idle-start" session))
+    (should (string-match-p ":dpms-set" session))
+    (should (string-match-p "ewwm-launch-native-target" launch))))
+
+(ert-deftest native-authority/raw-ipc-workspace-helpers-are-explicit ()
+  "Raw IPC workspace helpers should not override app-layer modules by load order."
+  (let ((ipc (native-authority-test--read-file "lisp/vr/ewwm-ipc.el")))
+    (should (string-match-p "ewwm-ipc-workspace-switch" ipc))
+    (should (string-match-p "ewwm-ipc-workspace-list" ipc))
+    (should (string-match-p "(unless (fboundp 'ewwm-workspace-switch)" ipc))
+    (should (string-match-p ":surface-float-changed" ipc))
+    (should (string-match-p ":surface-workspace-changed" ipc))
+    (should (string-match-p ":layout-changed" ipc))))
+
+(ert-deftest native-authority/proof-lanes-exist-and-avoid-emacs-authority ()
+  "Proof helpers should exercise native authority without relying on Emacs."
+  (let ((proof (native-authority-test--read-file
+                "packaging/scripts/xoxdwm-native-authority-proof"))
+        (boot (native-authority-test--read-file
+               "packaging/scripts/boot-without-emacs-smoke"))
+        (justfile (native-authority-test--read-file "justfile")))
+    (should (string-match-p "native_authority" proof))
+    (should (string-match-p ":workspace-list" proof))
+    (should (string-match-p ":layout-cycle" proof))
+    (should (string-match-p ":app-launch" proof))
+    (should (string-match-p "boot_without_emacs" boot))
+    (should (string-match-p "--backend headless" boot))
+    (should (string-match-p "^native-authority-proof" justfile))
+    (should (string-match-p "^remote-native-authority-proof" justfile))
+    (should (string-match-p "no reboot" justfile))))
+
+(ert-deftest native-authority/package-default-does-not-load-lisp-core ()
+  "Default RPM init should not add lisp/core to load-path."
+  (let* ((spec (native-authority-test--read-file "packaging/rpm/exwm-vr.spec"))
+         (start (string-match ";;; exwm-vr-init\\.el" spec))
+         (end (and start (string-match "ELISP_EOF" spec start)))
+         (snippet (and start end (substring spec start end))))
+    (should snippet)
+    (should-not (string-match-p "exwm-vr/core" snippet))
+    (should (string-match-p "compatibility/archive surface" snippet))))
+
+(provide 'native-authority-test)
+;;; native-authority-test.el ends here


### PR DESCRIPTION
Refs #45. Issue set: #53, #56, #62, #63. Stacked on #77.

## Scope
- Adds native authority proof and boot-without-Emacs smoke helpers.
- Adjusts RPM/session packaging so default package init does not load lisp/core as WM authority.
- Packages `/usr/libexec/exwm-vr/native-authority-proof` in the compositor RPM and asserts that ownership in the package guard.
- Adds static tests and just targets for no-default-Lisp and native-authority proof boundaries.

## Validation
- git diff --check
- just package-no-default-lisp-core-assert
- just boot-without-emacs-smoke 1 (skips runtime on non-Linux after cargo check; Linux remains the runtime proof host)
- just native-authority-test
- Honey live-session proof, 2026-05-10: built current branch as native Rocky RPM, extracted `exwm-vr-compositor-0.5.3-1.el10.x86_64.rpm`, staged its `/usr/bin/ewwm-compositor` with a temporary user-service override and config-backed `app_launch.true`, then ran packaged native-authority proof with Emacs inactive. Native IPC succeeded for hello, workspace list, focused surface, layout cycle, workspace switch, and configured app launch (`true`). Rollback restored packaged `/usr/bin/ewwm-compositor`.
- Verified on final stack tip: just test

Issue closure should happen only after the implementing PR has merged.