### PR TITLE
[codex] Fix main Elisp lint for IPC mirror state

### DIFF
--- a/lisp/vr/ewwm-ipc.el
+++ b/lisp/vr/ewwm-ipc.el
@@ -12,6 +12,11 @@
 (require 'cl-lib)
 (require 'ewwm-core)
 
+;; Optional app-layer modules own these variables; IPC only mirrors native state
+;; when the corresponding module is loaded.
+(defvar ewwm-layout--current)
+(defvar ewwm-workspace-current-index)
+
 ;; ── Customization ──────────────────────────────────────────
 
 (defcustom ewwm-ipc-socket-path nil
@@ -369,9 +374,11 @@ surfaces that still emit :old/:new."
 
 (defun ewwm-ipc--on-config-reloaded (msg)
   "Handle native :config-reloaded event MSG."
-  (when (plist-get msg :layout)
+  (when (and (boundp 'ewwm-layout--current)
+             (plist-get msg :layout))
     (setq ewwm-layout--current (intern (plist-get msg :layout))))
-  (when (plist-get msg :active-workspace)
+  (when (and (boundp 'ewwm-workspace-current-index)
+             (plist-get msg :active-workspace))
     (setq ewwm-workspace-current-index (plist-get msg :active-workspace)))
   (message "ewwm: native config reloaded"))
 

--- a/test/ewwm-ipc-test.el
+++ b/test/ewwm-ipc-test.el
@@ -6,6 +6,8 @@
 (require 'ewwm-ipc)
 (require 'ewwm-workspace)
 
+(defvar ewwm-layout--current)
+
 ;; ── Message encoding/decoding tests ────────────────────────
 
 (ert-deftest ewwm-ipc-test/encode-message-length-prefix ()
@@ -134,6 +136,14 @@
   "Dispatch handles unknown events gracefully."
   ;; Should not error
   (ewwm-ipc--dispatch '(:type :event :event :unknown-event :data 42)))
+
+(ert-deftest ewwm-ipc-test/config-reloaded-mirrors-loaded-module-state ()
+  "Config reload mirrors native state when app-layer modules are loaded."
+  (let ((ewwm-layout--current 'tiling)
+        (ewwm-workspace-current-index 0))
+    (ewwm-ipc--on-config-reloaded '(:layout "monocle" :active-workspace 2))
+    (should (eq ewwm-layout--current 'monocle))
+    (should (= ewwm-workspace-current-index 2))))
 
 ;; ── Connection state tests ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fix the post-merge `Lint Elisp` failure on `main` by declaring the optional IPC mirror variables that are owned by app-layer modules.

## Root Cause

`ewwm-ipc--on-config-reloaded` assigned `ewwm-layout--current` and `ewwm-workspace-current-index` directly. In strict byte compilation, `ewwm-layout--current` was treated as a free variable because `ewwm-ipc` intentionally loads before `ewwm-layout`.

## Changes

- Declare optional mirror variables in `ewwm-ipc.el` without initializing them, preserving optional module load behavior.
- Guard config reload mirroring with `boundp`, matching the existing event handlers.
- Add an IPC regression test for `:config-reloaded` mirroring when the app-layer state is loaded.

## Validation

- `git diff --check`
- `emacs --batch -L lisp/core -L lisp/vr -L lisp/ext --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/vr/ewwm-ipc.el`
- `emacs --batch -L lisp/core -L lisp/vr -L lisp/ext -l test/ewwm-ipc-test.el -f ert-run-tests-batch-and-exit`
- `nix develop --command just lint-elisp`
