### PR TITLE
docs: reconcile native authority planning surfaces

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # XoxdWM Status
 
-Snapshot date: 2026-05-09
+Snapshot date: 2026-05-10
 
 ## Honest Assessment
 
@@ -21,7 +21,7 @@ Snapshot date: 2026-05-09
 - The repo now carries `packaging/scripts/exwm-vr-hmd-connector` so setup/status/proof helpers resolve the headset as connected DP `non_desktop=1`, then BIG EDID `0x1234`/`0x5095`, then explicit override, instead of assuming Honey is always `DP-2`.
 - The May 2026 lab pass still failed human-visible first frame: the OpenXR session reached `FOCUSED`, but the goggles remained black. Treat this as `P3 OpenXR Session` pass / `P4 Visual First Frame` fail after successful host visibility, service lifecycle, DRM lease routing, runtime selection, and OpenXR session bring-up.
 - The packaged `beyond-power-on` helper had drifted from the corrected Rust HID implementation by placing the SetWorkState command at byte 2 instead of byte 1. The repo copy is now corrected and guarded by a substrate test; any installed Honey helper should be refreshed before using the service as panel-power evidence.
-- Native XoxdWM authority is now a code/static and headless-proofable lane: Rust owns configured workspace count, layout reflow, workspace visibility, native key actions, configured app-launch IPC, config reload, autostart, lock/logout, idle supervision, and DPMS IPC. It is not yet a named-host product proof until #45 records app launch, focus, workspace movement, and layout in a real Linux session without Emacs in the WM path.
+- Native XoxdWM authority now has a bounded named-host live-session proof: Rust owns configured workspace count, layout reflow, workspace visibility, native key actions, configured app-launch IPC, config reload, autostart, lock/logout, idle supervision, and DPMS IPC, and the `2026-05-10` Honey proof exercised native IPC hello, workspace list, focused surface, layout cycle, workspace switch, and configured app launch with `exwm-vr-emacs.service` inactive. GitHub #45 closed after merged PR #78. Remaining authority-adjacent product gates are narrower: IPC/config alias retirement (#46), legacy EXWM/X naming and package-surface retirement (#47), and eGreg app-layer polish (#48).
 - The active blockers on `honey` are now productization and repeatability, not missing lease support:
   - compositor-side headset connector designation and Monado direct-mode settings now both have supported host config surfaces, and `monado-beyond` is installed as a real host package on `honey`
   - the package-default `exwm-vr-monado.service` now runs `/usr/bin/monado-service` without `MONADO_SERVICE_BIN`, and the packaged launcher clears dead `monado_comp_ipc` sockets before launching when no `monado-service` is active

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -11,7 +11,7 @@ Status vocabulary:
 - `Synthetic`: code/static/headless proof exists, but no named visual runtime proof.
 - `Design`: code/docs/research exist, but the flow is not yet claimed as working on a named target.
 
-Date baseline: 2026-05-09.
+Date baseline: 2026-05-10.
 
 ## Honey XR Proof Ladder
 
@@ -78,7 +78,7 @@ For PREEMPT_RT specifically, use the Dell claim ladder:
 | --- | --- | --- |
 | Headless compositor | Smoke | Explicit build/test path exists. |
 | Desktop 2D compositor path | Smoke | Earlier bounded startup was proved on `yoga`, and the installed `0.5.4` user-unit path now reaches compositor plus Emacs initialization on the host. It is still not yet a polished local desktop/session lane. |
-| Native WM authority | Synthetic | Rust now owns static/configured workspace, layout, key-action, app-launch, config-reload, autostart, session, idle, and DPMS IPC surfaces. This is code/static and headless-proofable authority work; #45 stays open until a real Linux session proves app launch, focus, workspace movement, and layout without Emacs in the WM path. |
+| Native WM authority | Smoke | Rust owns static/configured workspace, layout, key-action, app-launch, config-reload, autostart, session, idle, and DPMS IPC surfaces. The `2026-05-10` Honey live-session proof exercised native IPC hello, workspace list, focused surface, layout cycle, workspace switch, and configured app launch with `exwm-vr-emacs.service` inactive; #45 closed after merged PR #78. This is bounded authority proof, not a polished daily-driver desktop claim. |
 | DRM backend on AMD | Smoke | Code exists and bounded named-host startup is now recorded on both `yoga` and `honey`; `honey` now also has direct-mode lease proof with Monado plus `hello_xr`, including packaged-client smoke across clean user-service cycles. It is not yet a fresh-boot operator lane. |
 | VR session lifecycle | Smoke | `honey` now has a direct-mode session proof where `hello_xr -g Vulkan` reached `FOCUSED` and created eye swapchains from the installed compositor package surface. The repo-owned OpenXR smoke wrapper plus installed smoke-client package give repeated smoke evidence, but the packaged-client path is not yet claimed as stable first-frame, long-running, or daily-driver proof because the current in-goggles result is black. |
 | DRM lease / HMD non-desktop handling | Smoke | The live `honey` direct-mode probe initializes `wp_drm_lease_v1`, keeps the explicitly designated headset connector out of the desktop output map, and grants a real lease to Monado. In May 2026 the live connector is `DP-1`; the kernel still does not expose a useful `non_desktop` sysfs property locally, so explicit connector designation remains required. |


### PR DESCRIPTION
## Summary
- Reconcile status/support planning surfaces after the native-authority stack merged.
- Move Native WM authority from `Synthetic` to bounded `Smoke` based on the 2026-05-10 Honey live-session proof with Emacs inactive.
- Replace stale `#45 stays open` language with the current remaining gates: #46, #47, and #48.

## Validation
- `git diff --check`
- `just truth-lint`
