### PR TITLE
[codex] Reconcile native IPC authority aliases

### DIFF
--- a/compositor/src/handlers/seat.rs
+++ b/compositor/src/handlers/seat.rs
@@ -59,10 +59,6 @@ impl SeatHandler for EwwmState {
                 &[("id", &new_str), ("previous-id", &old_str)],
             );
             IpcServer::broadcast_event(self, &event);
-
-            // Compatibility alias for older clients and tests.
-            let event = format_event("focus-changed", &[("old", &old_str), ("new", &new_str)]);
-            IpcServer::broadcast_event(self, &event);
         }
     }
 }

--- a/compositor/src/vr/gaze_focus.rs
+++ b/compositor/src/vr/gaze_focus.rs
@@ -607,7 +607,7 @@ impl GazeFocusEvent {
                 y,
             } => {
                 format!(
-                    "(:type :event :event :gaze-focus-requested :surface-id {} :dwell-ms {:.0} :x {:.0} :y {:.0})",
+                    "(:type :event :event :gaze-focus-request :surface-id {} :dwell-ms {:.0} :x {:.0} :y {:.0})",
                     surface_id, dwell_ms, x, y
                 )
             }

--- a/docs/ipc-protocol.md
+++ b/docs/ipc-protocol.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-The EWWM IPC protocol enables bidirectional communication between the Rust
-compositor (`ewwm-compositor`) and Emacs (`ewwm-ipc.el`) over a Unix domain
-socket. Emacs is the window management brain; the compositor is the pixel
-engine. All layout policy decisions flow from Emacs to the compositor via
-IPC commands; all state change notifications flow from the compositor to
-Emacs via IPC events.
+The EWWM IPC protocol enables bidirectional communication between the native
+Rust compositor (`ewwm-compositor`) and app-layer clients such as Emacs/eGreg
+over a Unix domain socket. The Rust compositor is the native WM/DE authority:
+it loads JSON-backed startup config, owns compositor policy state, and emits
+the resulting state transitions as IPC events. Emacs/eGreg clients may request
+policy changes and mirror compositor state for editor/app workflows, but they
+are not the WM authority.
 
 ## Transport
 
@@ -53,7 +54,7 @@ incremental parsing complexity.
 
 ## Message Structure
 
-### Request (Emacs -> Compositor)
+### Request (Client -> Compositor)
 
 ```elisp
 (:type MESSAGE-TYPE :id REQUEST-ID &rest PAYLOAD)
@@ -63,7 +64,7 @@ incremental parsing complexity.
 - `:id` — monotonically increasing integer for request/response correlation
 - Remaining fields are message-type-specific
 
-### Response (Compositor -> Emacs)
+### Response (Compositor -> Client)
 
 ```elisp
 (:type :response :id REQUEST-ID :status :ok|:error &rest PAYLOAD)
@@ -73,7 +74,7 @@ incremental parsing complexity.
 - `:status` — `:ok` for success, `:error` for failure
 - On error: `:reason "human-readable error message"`
 
-### Event (Compositor -> Emacs, unsolicited)
+### Event (Compositor -> Clients, unsolicited)
 
 ```elisp
 (:type :event :event EVENT-TYPE &rest PAYLOAD)
@@ -377,7 +378,7 @@ Latency measurement. Compositor responds immediately.
 ;; Response: (:type :response :id 20 :status :ok :client-timestamp 1705312345123 :server-timestamp 1705312345124)
 ```
 
-## Event Types (Compositor -> Emacs)
+## Event Types (Compositor -> Clients)
 
 Events are pushed to all connected clients. No acknowledgment required.
 
@@ -405,9 +406,20 @@ Events are pushed to all connected clients. No acknowledgment required.
 (:type :event :event :surface-focused :id 2 :previous-id 1)
 ```
 
-`:surface-focused` is the canonical focus event.  Legacy runtimes may also
-emit `:focus-changed` with `:old` and `:new`; clients should treat that as a
-temporary compatibility alias.
+`:surface-focused` is the canonical native focus event. Current Rust runtimes
+do not emit `:focus-changed`; Lisp clients may accept that legacy event as a
+client-only compatibility alias and map `:old`/`:new` onto
+`:previous-id`/`:id`.
+
+#### `:gaze-focus-request`
+
+```elisp
+(:type :event :event :gaze-focus-request :surface-id 2 :dwell-ms 450 :x 960 :y 540)
+```
+
+`:gaze-focus-request` is the canonical native gaze focus event. Lisp clients
+may accept the retired `:gaze-focus-requested` spelling as a client-only
+compatibility alias while old app/debug sessions are phased out.
 
 #### `:surface-geometry-changed`
 
@@ -474,6 +486,26 @@ a slow client from causing compositor memory growth.
   no benefit.
 - **Authorization:** All connected clients have full access. Future:
   capability-based access control.
+
+## Compatibility Aliases
+
+The v1 Rust dispatcher accepts these temporary command aliases for older
+clients:
+
+- `:launch-app` dispatches to canonical `:app-launch`.
+- `:reload-config` dispatches to canonical `:config-reload`.
+
+Runtime event aliases are client-only unless listed above as compositor
+events. In particular:
+
+- `:focus-changed` is a retired focus event; current Rust emits
+  `:surface-focused`.
+- `:gaze-focus-requested` is a retired gaze focus event; current Rust emits
+  `:gaze-focus-request`.
+
+Design-only or app-layer Lisp request types are outside the native runtime
+contract until promoted here and implemented by Rust dispatch. The IPC
+contract tests keep that boundary explicit.
 
 ## Performance Targets
 

--- a/lisp/vr/ewwm-vr-eye.el
+++ b/lisp/vr/ewwm-vr-eye.el
@@ -310,7 +310,8 @@ Functions receive (SURFACE-ID METHOD).")
     (setq ewwm-vr-eye--dwell-surface (plist-get msg :surface-id))))
 
 (defun ewwm-vr-eye--on-gaze-focus-request (msg)
-  "Handle :gaze-focus-request event MSG from compositor."
+  "Handle canonical :gaze-focus-request event MSG from compositor.
+Also accepts the retired :gaze-focus-requested spelling for legacy clients."
   (let ((sid (plist-get msg :surface-id))
         (dwell-ms (plist-get msg :dwell-ms)))
     (ewwm-vr-eye--process-focus-request sid dwell-ms)))
@@ -640,6 +641,7 @@ POLICY is a symbol: `gaze-only', `gaze-primary', `gaze-assist', or `disabled'."
      (:gaze-dwell            . ewwm-vr-eye--on-gaze-dwell)
      (:gaze-dwell-progress   . ewwm-vr-eye--on-gaze-dwell-progress)
      (:gaze-focus-request    . ewwm-vr-eye--on-gaze-focus-request)
+     (:gaze-focus-requested  . ewwm-vr-eye--on-gaze-focus-request)
      (:gaze-cooldown         . ewwm-vr-eye--on-gaze-cooldown)
      (:gaze-saccade-state    . ewwm-vr-eye--on-gaze-saccade-state)
      (:gaze-reading-mode     . ewwm-vr-eye--on-gaze-reading-mode))))

--- a/test/ewwm-vr-eye-focus-test.el
+++ b/test/ewwm-vr-eye-focus-test.el
@@ -2,9 +2,12 @@
 
 ;;; Code:
 
+(setq load-prefer-newer t)
+
 (require 'ert)
 (require 'cl-lib)
 (require 'ewwm-core)
+(require 'ewwm-ipc)
 (require 'ewwm-vr-eye)
 
 ;; Forward-declare dynamic variables
@@ -317,6 +320,7 @@
     (should (assq :gaze-dwell ewwm-ipc--event-handlers))
     (should (assq :gaze-dwell-progress ewwm-ipc--event-handlers))
     (should (assq :gaze-focus-request ewwm-ipc--event-handlers))
+    (should (assq :gaze-focus-requested ewwm-ipc--event-handlers))
     (should (assq :gaze-cooldown ewwm-ipc--event-handlers))
     (should (assq :gaze-saccade-state ewwm-ipc--event-handlers))
     (should (assq :gaze-reading-mode ewwm-ipc--event-handlers))))

--- a/test/ipc-contract-test.el
+++ b/test/ipc-contract-test.el
@@ -73,9 +73,7 @@
   "Current known Lisp request types that do not have Rust dispatch handlers.")
 
 (defconst ipc-contract-test--known-payload-debt
-  '("surface-resize geometry payload"
-    "focus event name/payload"
-    "gaze focus event name")
+  '("surface-resize geometry payload")
   "Known IPC schema debt not represented by command-name parity alone.")
 
 (defun ipc-contract-test--read-file (relative)
@@ -137,9 +135,44 @@
 
 (ert-deftest ipc-contract/known-schema-debt-is-explicit ()
   "Schema mismatches that command-name parity cannot see should stay explicit."
-  (dolist (item '("surface-resize geometry payload"
-                  "focus event name/payload"
-                  "gaze focus event name"))
+  (dolist (item '("surface-resize geometry payload"))
     (should (member item ipc-contract-test--known-payload-debt))))
+
+(ert-deftest ipc-contract/docs-do-not-make-emacs-the-wm-brain ()
+  "IPC docs should describe native authority, not Emacs WM authority."
+  (let ((docs (ipc-contract-test--read-file "docs/ipc-protocol.md")))
+    (should-not (string-match-p "Emacs is the window management brain" docs))
+    (should-not (string-match-p "All layout policy decisions flow from Emacs" docs))
+    (should (string-match-p "Rust compositor is the native WM/DE authority" docs))
+    (should (string-match-p "Emacs/eGreg clients" docs))
+    (should (string-match-p "not the WM authority" docs))))
+
+(ert-deftest ipc-contract/focus-event-legacy-alias-is-client-only ()
+  "Rust emits surface-focused; Lisp keeps focus-changed compatibility."
+  (let ((seat (ipc-contract-test--read-file "compositor/src/handlers/seat.rs"))
+        (lisp (ipc-contract-test--read-file "lisp/vr/ewwm-ipc.el")))
+    (should (string-match-p "\"surface-focused\"" seat))
+    (should (string-match-p "\"previous-id\"" seat))
+    (should-not (string-match-p "\"focus-changed\"" seat))
+    (should (string-match-p ":focus-changed" lisp))
+    (should (string-match-p "ewwm-ipc--on-focus-changed-compat" lisp))))
+
+(ert-deftest ipc-contract/gaze-focus-event-name-is-canonical ()
+  "Rust and Lisp agree on gaze-focus-request; Lisp accepts retired spelling."
+  (let ((rust (ipc-contract-test--read-file "compositor/src/vr/gaze_focus.rs"))
+        (lisp (ipc-contract-test--read-file "lisp/vr/ewwm-vr-eye.el")))
+    (should (string-match-p ":gaze-focus-request" rust))
+    (should-not (string-match-p ":gaze-focus-requested" rust))
+    (should (string-match-p ":gaze-focus-request[[:space:]]+\\. ewwm-vr-eye--on-gaze-focus-request" lisp))
+    (should (string-match-p ":gaze-focus-requested[[:space:]]+\\. ewwm-vr-eye--on-gaze-focus-request" lisp))))
+
+(ert-deftest ipc-contract/native-policy-aliases-are-documented ()
+  "Native aliases and client-only legacy events are explicitly documented."
+  (let ((docs (ipc-contract-test--read-file "docs/ipc-protocol.md")))
+    (dolist (token '(":launch-app" ":reload-config"
+                    ":focus-changed" ":gaze-focus-requested"))
+      (should (string-match-p (regexp-quote token) docs)))
+    (should (string-match-p "temporary command aliases" docs))
+    (should (string-match-p "client-only compatibility alias" docs))))
 
 ;;; ipc-contract-test.el ends here

--- a/test/v040-focus-cursor-test.el
+++ b/test/v040-focus-cursor-test.el
@@ -37,11 +37,11 @@
       (should (search-forward "pub enum CursorImageStatus" nil t)))))
 
 (ert-deftest v040/seat-focus-changed-emits-ipc ()
-  "focus_changed handler broadcasts IPC event."
+  "focus_changed handler broadcasts the canonical IPC event."
   (let ((file (expand-file-name "compositor/src/handlers/seat.rs" v040-test--root)))
     (with-temp-buffer
       (insert-file-contents file)
-      (should (search-forward "focus-changed" nil t)))))
+      (should (search-forward "surface-focused" nil t)))))
 
 (ert-deftest v040/seat-focus-changed-updates-state ()
   "focus_changed handler updates focused_surface state."
@@ -132,14 +132,20 @@
       (should (search-forward "(\"id\"" nil t))
       (should (search-forward "(\"previous-id\"" nil t)))))
 
-(ert-deftest v040/focus-event-keeps-compat-alias ()
-  "focus-changed remains a temporary compatibility alias."
+(ert-deftest v040/focus-event-does-not-emit-legacy-focus-changed ()
+  "Rust no longer emits the retired focus-changed alias."
   (let ((file (expand-file-name "compositor/src/handlers/seat.rs" v040-test--root)))
     (with-temp-buffer
       (insert-file-contents file)
-      (should (search-forward "focus-changed" nil t))
-      (should (search-forward "(\"old\"" nil t))
-      (should (search-forward "(\"new\"" nil t)))))
+      (should-not (search-forward "focus-changed" nil t)))))
+
+(ert-deftest v040/lisp-keeps-focus-changed-compat-handler ()
+  "Lisp keeps a client-only compatibility handler for focus-changed."
+  (let ((file (expand-file-name "lisp/vr/ewwm-ipc.el" v040-test--root)))
+    (with-temp-buffer
+      (insert-file-contents file)
+      (should (search-forward ":focus-changed" nil t))
+      (should (search-forward "ewwm-ipc--on-focus-changed-compat" nil t)))))
 
 (ert-deftest v040/focused-surface-returns-metadata ()
   "focused-surface response includes :app-id and :title."

--- a/test/week12-integration-test.el
+++ b/test/week12-integration-test.el
@@ -2,6 +2,8 @@
 
 ;;; Code:
 
+(setq load-prefer-newer t)
+
 (require 'ert)
 (require 'ewwm-core)
 (require 'ewwm-vr-eye)
@@ -237,7 +239,8 @@
       (goto-char (point-min))
       (should (search-forward ":gaze-dwell-progress" nil t))
       (goto-char (point-min))
-      (should (search-forward ":gaze-focus-requested" nil t))
+      (should (search-forward ":gaze-focus-request" nil t))
+      (should-not (search-forward ":gaze-focus-requested" nil t))
       (goto-char (point-min))
       (should (search-forward ":gaze-cooldown-started" nil t))
       (goto-char (point-min))


### PR DESCRIPTION
## Summary

- update IPC docs so Rust is the native WM/DE authority and Emacs/eGreg are app-layer IPC clients
- stop Rust from emitting retired event spellings for focus and gaze focus
- keep Lisp compatibility handlers explicit while contract tests guard alias/documentation drift

Closes #46

## Validation

- emacs --batch -Q -L lisp/core -L lisp/vr -L lisp/ext -l test/ipc-contract-test.el -l test/v040-focus-cursor-test.el -l test/week12-integration-test.el -l test/ewwm-vr-eye-focus-test.el -f ert-run-tests-batch-and-exit
- emacs --batch -Q -L lisp/core -L lisp/vr -L lisp/ext --eval '(setq load-prefer-newer t)' -l test/native-authority-test.el -l test/ewwm-ipc-test.el -f ert-run-tests-batch-and-exit
- cargo fmt --manifest-path compositor/Cargo.toml --check
- cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features
- just truth-lint
- git diff --check
