### PR TITLE
[codex] Document Honey PPS diagnostic lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is the canonical public home for the compositor, packaging, rele
 
 ## Current State
 
-As of 2026-05-09:
+As of 2026-05-12:
 
 | Area | Status | Notes |
 | --- | --- | --- |
@@ -14,7 +14,7 @@ As of 2026-05-09:
 | Headless compositor path | Smoke | Build and test surfaces exist, but not re-validated in this pass. |
 | Rocky 10 package install | Smoke | `yoga` now has refreshed installed `0.5.4-1.el10` `exwm-vr-*` RPMs from the current branch, the real installed units pass a named-host bounded proof, and a controlled SDDM autologin run reached a real `EXWM-VR` Wayland user session on `seat0`. The packaged `SuccessExitStatus=15` stop-path fix is now on-host; the remaining follow-on is repeatability and operator polish, not package repair. |
 | `honey` compositor/substrate path | Smoke | `honey` now has installed branch-scoped `exwm-vr-0.5.4-1.el10` packages, a bounded named-host `exwm-vr.target` startup, and a direct-mode lease proof from the installed `/usr/bin/ewwm-compositor` after reinstalling the branch RPM artifact from run `24776900393`. |
-| `honey` VR session | Smoke | On `2026-04-22`, the installed `ewwm-compositor` on `honey` initialized `wp_drm_lease_v1`, reserved the headset connector, and granted a real DRM lease to Monado. The repo-owned `exwm-vr-monado.service`, installed `monado-beyond` host package, `exwm-vr-openxr-smoke-client` RPM, and `just honey-openxr-*` wrappers now prove the packaged OpenXR client lane. On `2026-05-09`, the current Honey topology was `card0-DP-1` for the BS2E and `card0-HDMI-A-1` for the Dell panel, with `rke2-server` still active. After correcting the host config from the old `DP-2` target to `DP-1`, repeated `/usr/libexec/exwm-vr/hello_xr -g Vulkan` runs selected Monado / Bigscreen Beyond, created two `3561x3561` eye swapchains, and reached `READY -> SYNCHRONIZED -> VISIBLE -> FOCUSED`. The human-visible headset output remained black, so the current classification is P3 OpenXR Session pass / P4 Visual First Frame fail, not first-frame or daily-driver proof. |
+| `honey` VR session | Smoke | On `2026-04-22`, the installed `ewwm-compositor` on `honey` initialized `wp_drm_lease_v1`, reserved the headset connector, and granted a real DRM lease to Monado. The repo-owned `exwm-vr-monado.service`, installed `monado-beyond` host package, `exwm-vr-openxr-smoke-client` RPM, and `just honey-openxr-*` wrappers now prove the packaged OpenXR client lane. On `2026-05-09`, the current Honey topology was `card0-DP-1` for the BS2E and `card0-HDMI-A-1` for the Dell panel, with `rke2-server` still active. After correcting the host config from the old `DP-2` target to `DP-1`, repeated `/usr/libexec/exwm-vr/hello_xr -g Vulkan` runs selected Monado / Bigscreen Beyond, created two `3561x3561` eye swapchains, and reached `READY -> SYNCHRONIZED -> VISIBLE -> FOCUSED`. The human-visible headset output remained black, so the current classification is P3 OpenXR Session pass / P4 Visual First Frame fail. `linux-xr` PR #69 now provides the next read-only PPS diagnostic artifact lane, but that is observability only until installed and attended on `honey`. |
 | `yoga` desktop/dev target | Smoke | `yoga` now has an installed `0.5.4` session proof with explicit `drm` backend and dedicated Emacs bootstrap, plus a one-time SDDM greeter-path proof via `sddm-autologin` on `seat0`. The remaining work is repeatability and session polish, not basic launch viability or packaged stop-path repair. |
 | Eye tracking / hand tracking / BCI | Design | Documented and partially implemented, but not currently claimed as proven on named lab hosts. |
 
@@ -31,6 +31,7 @@ As of 2026-05-09:
 - [Honey Substrate Proof](docs/honey-substrate-proof-2026-04-22.md)
 - [Honey Fresh-Boot Runbook](docs/honey-fresh-boot-runbook-2026-04-26.md)
 - [Honey Fresh-Boot Evidence Template](docs/honey-fresh-boot-evidence-template.md)
+- [Honey PPS Diagnostic Runbook](docs/honey-pps-diagnostic-runbook-2026-05-12.md)
 - [Status](docs/status.md)
 - [Q2 2026 Roadmap](docs/roadmap-2026-q2.md)
 - [Installation Quickstart](docs/installation-quickstart.md)

--- a/docs/honey-fresh-boot-evidence-template.md
+++ b/docs/honey-fresh-boot-evidence-template.md
@@ -94,6 +94,34 @@ CLI smoke is not first-frame proof by itself.
 - If no visible frame, record `visual_observed=no` and classify as P3 pass /
   P4 fail even if CLI smoke reached `FOCUSED`.
 
+## Kernel / DSC PPS Evidence
+
+Use this section only when a diagnostic kernel with the `linux-xr` PPS debugfs
+carry is intentionally under test. Otherwise set `pps_available` to the observed
+value and leave the remaining fields empty.
+
+Command:
+
+```sh
+just honey-kernel-dsc-truth honey auto
+```
+
+Required fields:
+
+- kernel release:
+- resolved connector:
+- debugfs connector:
+- `debugfs_dsc_bits_per_pixel`:
+- `debugfs_dsc_pic_width`:
+- `debugfs_dsc_pic_height`:
+- `debugfs_dsc_slice_width`:
+- `debugfs_dsc_slice_height`:
+- `pps_available`:
+- `pps_sha256`:
+- `pps_bits_per_pixel_x16`:
+- `pps_rc_ranges_bpp8_444_patched`:
+- `pps_rc_ranges_bpp8_444_stock`:
+
 ## Classification
 
 Select exactly one primary classification:

--- a/docs/honey-pps-diagnostic-runbook-2026-05-12.md
+++ b/docs/honey-pps-diagnostic-runbook-2026-05-12.md
@@ -1,0 +1,158 @@
+# `honey` PPS Diagnostic Runbook - 2026-05-12
+
+## Scope
+
+Use this runbook to capture the packed AMD DSC Picture Parameter Set (PPS)
+for the Bigscreen Beyond stream on `honey` after the `linux-xr` read-only PPS
+debugfs carry is available in a diagnostic kernel.
+
+This is evidence capture only. It does not prove a visible first frame, does
+not promote `honey` beyond the current P3 OpenXR Session pass / P4 Visual First
+Frame fail classification, and does not move host/kernel authority into
+XoxdWM.
+
+## Current Artifact Lane
+
+- Kernel repo: `tinyland-inc/linux-xr`
+- PPS carry PR: <https://github.com/tinyland-inc/linux-xr/pull/69>
+- Merge commit: `dbfcd3938a2f3`
+- Post-merge CI: <https://github.com/tinyland-inc/linux-xr/actions/runs/25710732827>
+- Artifact-only diagnostic build: <https://github.com/tinyland-inc/linux-xr/actions/runs/25710987473>
+- Intended diagnostic release string: `6.19.5-xr12`, generic variant
+
+Use a successful generic RPM artifact from that run or a later equivalent run.
+Do not treat a workflow artifact as a tagged release unless `linux-xr` cuts an
+actual release tag.
+
+## Hard Boundaries
+
+- Do not install a kernel, change the default boot entry, reboot `honey`, or
+  restart XoxdWM/Monado services without explicit attended operator approval.
+- Do not stop, restart, drain, or otherwise touch `rke2`.
+- Do not write debugfs as part of this PPS capture. `just honey-kernel-dsc-truth`
+  copies a helper to `/tmp` and reads sysfs/debugfs through the Honey sudo lane;
+  it must not retrain the link or write connector state.
+- Keep Dell reset, BIOS, SMI, power, and management-display facts in the
+  Dell-7810 evidence surface. Link those artifacts from the final tracker
+  comment instead of turning them into XoxdWM product claims.
+
+## Read-Only Baseline
+
+Before any diagnostic kernel install or reboot, capture the current state:
+
+```sh
+gh run view 25710987473 -R tinyland-inc/linux-xr --json status,conclusion,url
+just honey-openxr-status honey
+just honey-kernel-dsc-truth honey auto
+```
+
+Record:
+
+- current kernel from `kernel_release`
+- resolved connector and source
+- OpenXR client path
+- service/socket state
+- `debugfs_dsc_bits_per_pixel`
+- `debugfs_dsc_pic_width`
+- `debugfs_dsc_pic_height`
+- `debugfs_dsc_slice_width`
+- `debugfs_dsc_slice_height`
+- `pps_available`
+
+On the pre-diagnostic `6.19.5-10.xr.el10` host, the known result is
+`pps_available=false` because the live kernel does not expose
+`dsc_pic_parameter_set`.
+
+## Diagnostic Kernel Activation
+
+Only after operator approval:
+
+1. Download the generic RPM artifact from the selected `linux-xr` Actions run.
+2. Record the artifact URL, artifact name, RPM filenames, and checksums.
+3. Install the RPM through the approved Honey sudo/become path.
+4. Record the previous default kernel and the new default kernel.
+5. Reboot only with an attended operator present and a rollback path available.
+6. After boot, verify `uname -r` before starting any visual or OpenXR proof.
+
+For tagged `linux-xr` releases, `just beyond-kernel-install honey <tag>` is the
+repo-owned release helper. For workflow artifacts, use the explicit downloaded
+RPM paths instead of pretending there is a release tag.
+
+## Active PPS Capture
+
+The useful sample is the live HMD stream while Monado/OpenXR has driven the
+Bigscreen Beyond path into active presentation.
+
+Use two shells from `neo`:
+
+```sh
+just honey-openxr-status honey
+just honey-openxr-smoke honey -- --timeout 120
+```
+
+While the smoke client is still running or immediately after it reaches
+`FOCUSED`, capture DSC/PPS truth:
+
+```sh
+just honey-kernel-dsc-truth honey auto
+```
+
+Required PPS fields:
+
+- `pps_available=true`
+- `pps_length=128`
+- `pps_sha256`
+- `pps_hex_0_127`
+- `pps_bits_per_pixel_x16=128`
+- `pps_pic_width=5088`
+- `pps_pic_height=2544`
+- `pps_slice_width=1272`
+- `pps_slice_height=159`
+- `pps_rc_ranges_bpp8_444_patched=true`
+- `pps_rc_ranges_bpp8_444_stock=false`
+
+If `pps_available=false`, the run is still useful evidence, but the PPS gap is
+not closed. Record the kernel release, debugfs connector, debugfs file list if
+available, OpenXR state, and whether the stream was active at capture time.
+
+## Visual Gate
+
+Record the human-visible result separately:
+
+- `visual_observed=yes`: visible non-black HMD output was observed by the lab
+  operator during the active run.
+- `visual_observed=no`: OpenXR/Monado reached session proof but goggles stayed
+  black.
+- `visual_observed=not_observed`: no person was watching the headset.
+
+Do not promote #49 unless `visual_observed=yes` is backed by an attended
+evidence packet.
+
+## Tracker Draft
+
+```markdown
+PPS diagnostic evidence:
+
+- linux-xr source:
+- artifact run:
+- artifact name/checksum:
+- Honey kernel before:
+- Honey kernel after:
+- boot ID:
+- resolved connector:
+- OpenXR client:
+- runtime/headset:
+- session state:
+- `pps_available`:
+- `pps_sha256`:
+- `pps_bits_per_pixel_x16`:
+- `pps_pic_width` / `pps_pic_height`:
+- `pps_slice_width` / `pps_slice_height`:
+- `pps_rc_ranges_bpp8_444_patched`:
+- `pps_rc_ranges_bpp8_444_stock`:
+- `visual_observed`:
+- `rke2-server` state:
+- classification:
+
+Notes:
+```

--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -1,6 +1,6 @@
 # XoxdWM Remote Proof Lanes
 
-Snapshot date: 2026-04-25
+Snapshot date: 2026-05-12
 
 This document names the remote workflow and host lanes that actually matter when
 you are operating XoxdWM from `neo`.
@@ -14,6 +14,8 @@ For the next attended `honey` fresh-boot proof, use
 [honey-fresh-boot-runbook-2026-04-26.md](honey-fresh-boot-runbook-2026-04-26.md).
 Record the result with
 [honey-fresh-boot-evidence-template.md](honey-fresh-boot-evidence-template.md).
+For the read-only packed DSC PPS diagnostic lane after `linux-xr` PR #69, use
+[honey-pps-diagnostic-runbook-2026-05-12.md](honey-pps-diagnostic-runbook-2026-05-12.md).
 
 ## Core Distinction
 
@@ -57,6 +59,7 @@ Not every remote workflow is authoritative in the same way.
    - `just honey-openxr-smoke`
    - `just honey-openxr-clean-cycle`
    - `just honey-openxr-fresh-boot-check`
+   - `just honey-kernel-dsc-truth`
 4. Inspect the live remote surface with `just remote-proof-surface` and
    `just remote-proof-runs`.
 5. Dispatch bounded remote checks when needed:
@@ -119,6 +122,13 @@ The repo now has a thin explicit remote-dev/operator lane for working from
     fresh boot has completed
   - use [honey-fresh-boot-runbook-2026-04-26.md](honey-fresh-boot-runbook-2026-04-26.md)
     for the evidence checklist and pass/fail criteria
+- `just honey-kernel-dsc-truth`
+  - copy the repo-owned DSC truth helper to `/tmp` on `honey`, then read kernel
+    module, EDID, connector debugfs, and packed PPS state through the Honey sudo
+    lane
+  - this target is read-only with respect to debugfs and must not be combined
+    with link retraining or service mutation unless the operator has explicitly
+    approved a broader attended run
 
 This lane is for live host work such as:
 
@@ -126,6 +136,8 @@ This lane is for live host work such as:
 - systemd unit inspection
 - DRM, Wayland, and IPC debugging
 - running repo commands on the real Linux host from `neo`
+- reading DSC/PPS truth for the active HMD connector after a diagnostic kernel
+  artifact is intentionally selected
 
 It is not a replacement for the external Bazel control plane in `rockies`.
 Use `rockies` when the work is really Rocky graph/orchestration policy rather

--- a/docs/research/honey-kernel-dsc-truth-2026-05-10.md
+++ b/docs/research/honey-kernel-dsc-truth-2026-05-10.md
@@ -188,27 +188,16 @@ Sibling repo checks on May 10 keep the ownership split as follows:
   but not fully converged into host IaC. Do not use cluster drain, reboot, or
   rke2 operations as part of PPS evidence capture.
 
-The repo now carries a read-only kernel patch draft:
+The read-only PPS patch now lives in `linux-xr` as
+`xr/patches/amdgpu-dsc-pps-debugfs.patch`. It adds a connector debugfs file
+named `dsc_pic_parameter_set` that dumps the cached
+`dc_stream_state.dsc_packed_pps[128]` as hex bytes. This is the payload AMD DC
+already generates in `dsc_get_packed_pps()` and stores on the stream before
+sending the PPS SDP; the patch only reads it back.
 
-```text
-patches/amdgpu-dsc-pps-debugfs.patch
-```
-
-It adds a connector debugfs file named `dsc_pic_parameter_set` that dumps the
-cached `dc_stream_state.dsc_packed_pps[128]` as hex bytes. This is the payload
-AMD DC already generates in `dsc_get_packed_pps()` and stores on the stream
-before sending the PPS SDP; the patch only reads it back. It has been checked
-with:
-
-```bash
-git -C /Users/jess/git/linux-xr apply --check \
-  /Users/jess/git/XoxdWM/patches/amdgpu-dsc-pps-debugfs.patch
-```
-
-The diagnostic patch has also been staged in the `linux-xr-fast` release-carry
-repo as `xr/patches/amdgpu-dsc-pps-debugfs.patch`, listed after the existing
-DSC and Beyond EDID patches in `xr/patches/series`, and applied from
-`xr/specs/kernel-xr.spec` as `Patch20`.
+The patch merged through <https://github.com/tinyland-inc/linux-xr/pull/69> at
+`dbfcd3938a2f3`. It is listed after the existing DSC and Beyond EDID patches in
+`xr/patches/series` and applied from `xr/specs/kernel-xr.spec` as `Patch20`.
 
 The staged carry was validated with:
 
@@ -232,6 +221,13 @@ apply the patch. Both kernel carry dry-runs apply the full `series` with zero
 fuzz against kernel.org tarballs. This does not make the patch a visual fix; it
 only gives the next test kernel a read-only way to prove the exact packed PPS
 bytes that AMD DC cached for the live stream.
+
+Post-merge, Determinate CI passed for `xr/main` in run `25710732827`. An
+artifact-only generic diagnostic RPM build for `6.19.5-xr12` was dispatched as
+run `25710987473`; this is not a release tag and does not mutate `honey`.
+
+The attended operator procedure for using that artifact is captured in
+[honey-pps-diagnostic-runbook-2026-05-12.md](../honey-pps-diagnostic-runbook-2026-05-12.md).
 
 Useful next steps:
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # XoxdWM Status
 
-Snapshot date: 2026-05-10
+Snapshot date: 2026-05-12
 
 ## Honest Assessment
 
@@ -20,6 +20,7 @@ Snapshot date: 2026-05-10
 - Current live Honey topology from the May 2026 lab pass is `card0-DP-1` for BS2E and `card0-HDMI-A-1` for the Dell management panel, not the older April `DP-2`/`HDMI-A-2` mapping. Host config must follow the live connector sample before attempting goggles proof.
 - The repo now carries `packaging/scripts/exwm-vr-hmd-connector` so setup/status/proof helpers resolve the headset as connected DP `non_desktop=1`, then BIG EDID `0x1234`/`0x5095`, then explicit override, instead of assuming Honey is always `DP-2`.
 - The May 2026 lab pass still failed human-visible first frame: the OpenXR session reached `FOCUSED`, but the goggles remained black. Treat this as `P3 OpenXR Session` pass / `P4 Visual First Frame` fail after successful host visibility, service lifecycle, DRM lease routing, runtime selection, and OpenXR session bring-up.
+- `linux-xr` PR #69 merged a read-only AMD DSC PPS debugfs carry at `dbfcd3938a2f3`; the follow-up diagnostic artifact lane is `6.19.5-xr12` generic from Actions run `25710987473`. This is PPS observability for the black-goggles lane, not a visual fix or P4 proof until installed, captured, and observed on `honey`.
 - The packaged `beyond-power-on` helper had drifted from the corrected Rust HID implementation by placing the SetWorkState command at byte 2 instead of byte 1. The repo copy is now corrected and guarded by a substrate test; any installed Honey helper should be refreshed before using the service as panel-power evidence.
 - Native XoxdWM authority now has a bounded named-host live-session proof: Rust owns configured workspace count, layout reflow, workspace visibility, native key actions, configured app-launch IPC, config reload, autostart, lock/logout, idle supervision, and DPMS IPC, and the `2026-05-10` Honey proof exercised native IPC hello, workspace list, focused surface, layout cycle, workspace switch, and configured app launch with `exwm-vr-emacs.service` inactive. GitHub #45 closed after merged PR #78, and IPC/config alias retirement closed with #46 after merged PR #82. Remaining authority-adjacent product gates are narrower: legacy EXWM/X retirement (#47), where this slice makes protocol-neutral app metadata canonical and keeps Emacs/eGreg Elisp out of the default package hard-dependency path, and eGreg app-layer polish (#48).
 - The active blockers on `honey` are now productization and repeatability, not missing lease support:
@@ -87,7 +88,7 @@ Snapshot date: 2026-05-10
 ## Immediate Priorities
 
 1. Preserve the now-explicit `monado_comp_ipc` cleanup path in the launcher and keep the `honey` OpenXR status wrapper as the safe preflight.
-2. Preserve the installed `monado-beyond` host lane on `honey`, refresh the corrected `beyond-power-on` helper on-host, and resolve the black first-frame blocker before promoting OpenXR smoke to product evidence.
+2. Preserve the installed `monado-beyond` host lane on `honey`, refresh the corrected `beyond-power-on` helper on-host, capture packed DSC PPS on the diagnostic kernel, and resolve the black first-frame blocker before promoting OpenXR smoke to product evidence.
 3. Keep using the installed `exwm-vr-openxr-smoke-client` path for honey OpenXR smoke runs and record whether failures are host/substrate, packaging/deployment, or compositor/runtime blockers.
 4. Keep the Rocky base package lane green while leaving Monado, SELinux, and BCI as separate follow-on concerns.
 5. Preserve the now-proven `yoga` package/session lane as the 2D reference host while packaging continues to evolve.


### PR DESCRIPTION
## Summary

- add a Honey PPS diagnostic runbook for the linux-xr PR #69 read-only DSC PPS carry
- update the fresh-boot evidence template with PPS fields
- link the PPS lane from README, status, remote proof lanes, and the kernel DSC truth note

## Tracking

- XoxdWM #49
- XoxdWM #20
- Linear TIN-346
- Linear TIN-1086

## Boundary

This is documentation and tracker plumbing only. It does not install a kernel, reboot Honey, touch rke2, write debugfs, or claim P4 visual first-frame proof.

## Validation

- `git diff --check`
- `just truth-lint`