### PR TITLE
Assert native package target authority

### DIFF
--- a/docs/research/legacy-exwm-x-retirement-inventory-2026-05-12.md
+++ b/docs/research/legacy-exwm-x-retirement-inventory-2026-05-12.md
@@ -46,6 +46,7 @@ available without letting X11 define the default product shape.
 
 - `native-authority/package-default-does-not-load-lisp-core`
 - `native-authority/default-session-target-does-not-pull-emacs`
+- `just package-no-default-lisp-core-assert`
 - `native-authority/xwayland-is-optional-compatibility-feature`
 - `ipc-contract/surface-metadata-is-protocol-neutral`
 - `just build-compositor-xwayland`

--- a/justfile
+++ b/justfile
@@ -124,7 +124,12 @@ package-no-default-lisp-core-assert:
     python3 - <<'PY'
     from pathlib import Path
 
-    spec = Path("{{project_root}}/packaging/rpm/exwm-vr.spec").read_text()
+    root = Path("{{project_root}}")
+    spec = (root / "packaging/rpm/exwm-vr.spec").read_text()
+    xoxdwm_target = (root / "packaging/systemd/xoxdwm.target").read_text()
+    legacy_target = (root / "packaging/systemd/exwm-vr.target").read_text()
+    emacs_service = (root / "packaging/systemd/exwm-vr-emacs.service").read_text()
+    session = (root / "packaging/desktop/exwm-vr-session").read_text()
     start = spec.index(";;; exwm-vr-init.el")
     end = spec.index("ELISP_EOF", start)
     snippet = spec[start:end]
@@ -138,7 +143,28 @@ package-no-default-lisp-core-assert:
         raise SystemExit("RPM must install native-authority-proof helper")
     if "%{_libexecdir}/%{project_name}/native-authority-proof" not in spec:
         raise SystemExit("RPM compositor package must own native-authority-proof helper")
+    if "Source25:       xoxdwm.target" not in spec:
+        raise SystemExit("RPM must source the native xoxdwm.target as a real unit")
+    if "ln -s exwm-vr.target" in spec:
+        raise SystemExit("RPM must not package xoxdwm.target as an exwm-vr.target symlink")
+    if "exwm-vr-emacs.service" in xoxdwm_target:
+        raise SystemExit("native xoxdwm.target must not want the Emacs app-layer service")
+    if "Wants=exwm-vr-compositor.service" not in xoxdwm_target:
+        raise SystemExit("native xoxdwm.target must want the compositor service")
+    if "Alias=xoxdwm.target" in legacy_target:
+        raise SystemExit("legacy exwm-vr.target must not alias the native xoxdwm.target")
+    if "Wants=exwm-vr-compositor.service exwm-vr-emacs.service" not in legacy_target:
+        raise SystemExit("legacy exwm-vr.target should remain the explicit Emacs compatibility path")
+    if "WantedBy=xoxdwm.target" in emacs_service or "PartOf=xoxdwm.target" in emacs_service:
+        raise SystemExit("Emacs app-layer service must not install into or bind to xoxdwm.target")
+    if "WantedBy=exwm-vr.target" not in emacs_service:
+        raise SystemExit("Emacs app-layer service should remain available through exwm-vr.target")
+    if "/usr/bin/emacs --fg-daemon" in session:
+        raise SystemExit("display-manager wrapper fallback must not launch Emacs by default")
+    if "/usr/share/exwm-vr/exwm-vr-session-init.el" in session:
+        raise SystemExit("display-manager wrapper fallback must not load the Emacs bootstrap by default")
     print("package_no_default_lisp_core=passed")
+    print("package_native_target_graph=passed")
     PY
 
 [group('test')]

--- a/test/native-authority-test.el
+++ b/test/native-authority-test.el
@@ -122,6 +122,7 @@
 (ert-deftest native-authority/package-default-does-not-load-lisp-core ()
   "Default RPM init should not add lisp/core to load-path."
   (let* ((spec (native-authority-test--read-file "packaging/rpm/exwm-vr.spec"))
+         (justfile (native-authority-test--read-file "justfile"))
          (start (string-match ";;; exwm-vr-init\\.el" spec))
          (end (and start (string-match "ELISP_EOF" spec start)))
          (snippet (and start end (substring spec start end))))
@@ -129,7 +130,10 @@
     (should-not (string-match-p "exwm-vr/core" snippet))
     (should (string-match-p "compatibility/archive surface" snippet))
     (should-not (string-match-p "^Requires:[[:space:]]+%{name}-elisp" spec))
-    (should (string-match-p "^Suggests:[[:space:]]+%{name}-elisp" spec))))
+    (should (string-match-p "^Suggests:[[:space:]]+%{name}-elisp" spec))
+    (should (string-match-p "package_native_target_graph=passed" justfile))
+    (should (string-match-p "native xoxdwm.target must not want the Emacs app-layer service"
+                            justfile))))
 
 (ert-deftest native-authority/default-session-target-does-not-pull-emacs ()
   "The primary XoxdWM target should start native authority without Emacs."


### PR DESCRIPTION
## Summary
- Extend `just package-no-default-lisp-core-assert` so it proves the default package/session graph keeps `xoxdwm.target` native-only.
- Assert the RPM packages a real `xoxdwm.target`, not an `exwm-vr.target` symlink.
- Assert the display-manager fallback does not launch Emacs or load the Emacs bootstrap by default.
- Add the `just` proof to the EXWM/X retirement guardrail inventory.

Part of #47. Builds on #87.

## Validation
- `git diff --check`
- `just package-no-default-lisp-core-assert`
- `just native-authority-test`
- `just truth-lint`
