### PR TITLE
[codex] Make Honey OpenXR status lightweight

### DIFF
--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -104,7 +104,10 @@ The repo now has a thin explicit remote-dev/operator lane for working from
   - print the remote repo path, runtime dir, key IPC sockets, and current
     user-service activity
 - `just honey-openxr-status`
-  - run the repo-owned OpenXR wrapper in status-only mode on `honey`
+  - run the repo-owned OpenXR wrapper in status-only mode on `honey` over a
+    plain SSH read path
+  - this intentionally avoids the remote `nix develop` lane so status capture
+    does not realize the full dev shell before printing runtime state
   - this does not start services or launch an OpenXR client
 - `just honey-openxr-smoke`
   - run the repo-owned OpenXR wrapper against the active Monado runtime

--- a/justfile
+++ b/justfile
@@ -853,7 +853,14 @@ honey-proof-env host="honey":
 
 [group('ci')]
 honey-openxr-status host="honey":
-    just honey-run {{host}} -- './packaging/scripts/exwm-vr-openxr-smoke --status-only'
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ssh jess@{{host}} bash -s <<'REMOTE'
+    set -euo pipefail
+    cd "{{remote_repo_path}}"
+    export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    ./packaging/scripts/exwm-vr-openxr-smoke --status-only
+    REMOTE
 
 [group('ci')]
 honey-openxr-smoke host="honey" *args="":

--- a/test/honey-substrate-test.el
+++ b/test/honey-substrate-test.el
@@ -573,6 +573,20 @@
       (should-not (string-match-p (regexp-quote "cmd='{{args}}'") justfile))
       (should-not (string-match-p (regexp-quote "exec nix develop --command \"$@\"") justfile)))))
 
+(ert-deftest honey-substrate/honey-openxr-status-uses-plain-read-only-ssh ()
+  "The status-only OpenXR lane should not enter the full remote dev shell."
+  (with-temp-buffer
+    (insert-file-contents honey-substrate--justfile)
+    (let* ((justfile (buffer-string))
+           (start (string-match "^honey-openxr-status host=\"honey\":" justfile))
+           (end (and start (string-match "^\\[group" justfile (1+ start))))
+           (stanza (and start end (substring justfile start end))))
+      (should stanza)
+      (should (string-match-p (regexp-quote "ssh jess@{{host}} bash -s") stanza))
+      (should (string-match-p (regexp-quote "./packaging/scripts/exwm-vr-openxr-smoke --status-only") stanza))
+      (should-not (string-match-p (regexp-quote "just honey-run") stanza))
+      (should-not (string-match-p (regexp-quote "nix develop") stanza)))))
+
 (ert-deftest honey-substrate/remote-authority-doc-separates-direnv-honey-and-bazel ()
   "Remote authority docs should keep local direnv, `honey` devshells, and `rockies` Bazel distinct."
   (with-temp-buffer


### PR DESCRIPTION
## Summary

References #49; the Honey P4 tracker remains open.

This keeps the Honey OpenXR status lane read-only and lightweight:

- `just honey-openxr-status` now runs the repo-owned status wrapper over plain SSH instead of `just honey-run`.
- `honey-openxr-smoke` and the client-launching lanes still use the remote `nix develop` path.
- `docs/remote-proof-lanes.md` documents that status-only intentionally avoids remote dev-shell realization.
- ERT coverage prevents the status-only recipe from drifting back into `nix develop`.

This PR is proof-lane hygiene only. P4 visual-first-frame proof is not claimed.

## Validation

- `git diff --check`
- `just truth-lint`
- focused `^honey-substrate/` ERT: 27/27
- `just honey-openxr-status honey`

## Hardware Boundary

The live Honey check was status-only. It did not reboot Honey, install a kernel, restart services, touch `rke2`, write debugfs, retrain DP, launch an OpenXR client, or claim `visual_observed=yes`.
