### PR TITLE
Remove hosted CI cache post-step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Byte-compile all Elisp
         run: nix develop --command just build
 
@@ -62,8 +60,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Run ERT test suite
         run: nix develop --command just test
 
@@ -75,8 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Lint Elisp (strict byte-compile)
         run: nix develop --command just lint-elisp
 
@@ -88,8 +82,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Run truth-surface checks
         run: nix develop --command just truth-lint
 
@@ -101,8 +93,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Check flake evaluates
         run: nix flake check --no-build
       - name: Build devShell
@@ -116,8 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
-        continue-on-error: true
       - name: Validate Dhall boot types and configs
         run: |
           nix shell nixpkgs#dhall --command bash -c '


### PR DESCRIPTION
## Summary

References #49; tracker remains open.

The post-merge `6452916` CI run completed Byte Compile successfully, then remained in `Post Run DeterminateSystems/magic-nix-cache-action@v8`. This mirrors the cache post-step hang that was already removed from Changelog Validate.

This removes `magic-nix-cache-action@v8` from the hosted `CI` workflow jobs while keeping:

- `actions/checkout@v4`
- `cachix/install-nix-action@v30`
- each job's actual `nix develop`, `nix flake`, or Dhall validation command

The Multi-Architecture workflow is unchanged in this PR.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `just truth-lint`

## Boundary

This is CI hygiene only. It does not change Honey runtime behavior and does not perform any Honey upload, kernel install, reboot, service restart, `rke2` operation, debugfs write, DP retrain, OpenXR client launch, DSC/PPS capture, or visual-first-frame observation.
