### PR TITLE
Remove Multi-Architecture cache post-step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - 'flake.nix'
       - 'flake.lock'
       - 'justfile'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/*.yml'
       - '.github/actions/**'
   pull_request:
     branches: [main, dev]
@@ -27,7 +27,7 @@ on:
       - 'flake.nix'
       - 'flake.lock'
       - 'justfile'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/*.yml'
       - '.github/actions/**'
   workflow_dispatch:
 

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -224,7 +224,6 @@ jobs:
         with:
           extra-conf: |
             system-features = kvm nixos-test
-      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Build ewwm-elisp package
         run: nix build .#ewwm-elisp

--- a/test/truth-surface-test.el
+++ b/test/truth-surface-test.el
@@ -106,7 +106,16 @@
   "CI should notice doc and README drift."
   (let ((workflow (truth-surface-test--read-file ".github/workflows/ci.yml")))
     (should (string-match-p "README\\.md" workflow))
-    (should (string-match-p "docs/\\*\\*" workflow))))
+    (should (string-match-p "docs/\\*\\*" workflow))
+    (should (string-match-p "\\.github/workflows/\\*\\.yml" workflow))))
+
+(ert-deftest truth-surface/hosted-ci-avoids-magic-cache-post-step ()
+  "Hosted CI workflows should not depend on the magic cache post-step."
+  (dolist (relative '(".github/workflows/ci.yml"
+                      ".github/workflows/multi-arch.yml"))
+    (should-not
+     (string-match-p "magic-nix-cache-action"
+                     (truth-surface-test--read-file relative)))))
 
 (ert-deftest truth-surface/readme-links-remote-build-authority ()
   "README should link the explicit remote-build authority doc."


### PR DESCRIPTION
## Summary

References #49; tracker remains open.

- removes `DeterminateSystems/magic-nix-cache-action@main` from the Multi-Architecture NixOS VM integration job after run `25781808617` completed the VM work and then stalled in that cache post-step
- expands hosted CI path filters from only `ci.yml` to `.github/workflows/*.yml` so workflow edits get regular truth-lint coverage
- adds a truth-surface ERT guard preventing `magic-nix-cache-action` from returning to `ci.yml` or `multi-arch.yml`

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/ci.yml .github/workflows/multi-arch.yml`
- `rg -n "magic-nix-cache-action|DeterminateSystems/magic" .github/workflows/ci.yml .github/workflows/multi-arch.yml` returned no matches
- `just truth-lint`

## Boundary

This is CI reliability work only. It does not change Honey runtime behavior and performs no Honey upload, kernel install, reboot, service restart, `rke2` operation, debugfs write, DP retrain, OpenXR client launch, DSC/PPS capture, or visual-first-frame observation.
