### PR TITLE
Add Honey P4 evidence checker

### DIFF
--- a/docs/honey-p4-visual-first-frame-evidence-template.md
+++ b/docs/honey-p4-visual-first-frame-evidence-template.md
@@ -75,7 +75,7 @@ If the lab observer sees visible non-black headset output during the active
 session, rerun or launch the smoke with the explicit P4 confirmation gate:
 
 ```sh
-just honey-run honey -- 'EXWM_VR_VISUAL_OBSERVED=yes EXWM_VR_VISUAL_OBSERVER=lab-observer EXWM_VR_VISUAL_CONFIRMATION=VISIBLE_NON_BLACK ./packaging/scripts/exwm-vr-openxr-smoke --timeout 120'
+just honey-run honey -- 'EXWM_VR_VISUAL_OBSERVED=yes EXWM_VR_VISUAL_OBSERVER=<observer-id> EXWM_VR_VISUAL_CONFIRMATION=VISIBLE_NON_BLACK ./packaging/scripts/exwm-vr-openxr-smoke --timeout 120'
 ```
 
 Paste the selected output:
@@ -193,6 +193,19 @@ Honey P4 visual-first-frame evidence:
 
 Notes:
 ```
+
+Before posting a P4 pass tracker comment, save the filled packet or draft
+comment locally and run:
+
+```sh
+just honey-p4-evidence-check path/to/filled-p4-packet.md
+./packaging/scripts/exwm-vr-p4-evidence-check --require-p4 path/to/filled-p4-packet.md
+```
+
+The checker is local/tracker-side only. It does not touch `honey`, but it rejects
+P4 promotion claims unless `visual_observed=yes`, a non-placeholder
+`visual_observer`, `visual_confirmation=VISIBLE_NON_BLACK`, and
+`visual_first_frame=P4_OBSERVED` are all present.
 
 ## Promotion Decision
 

--- a/justfile
+++ b/justfile
@@ -962,6 +962,10 @@ honey-openxr-fresh-boot-check host="honey" cycles="1" timeout="20":
     ./packaging/scripts/exwm-vr-openxr-smoke --status-only'
     just honey-openxr-clean-cycle "{{host}}" "${cycles}" "${timeout_seconds}"
 
+[group('ci')]
+honey-p4-evidence-check evidence="-":
+    ./packaging/scripts/exwm-vr-p4-evidence-check "{{evidence}}"
+
 # ── nix ────────────────────────────────────────────────
 
 [group('nix')]

--- a/packaging/scripts/exwm-vr-p4-evidence-check
+++ b/packaging/scripts/exwm-vr-p4-evidence-check
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate filled Honey P4 visual first-frame evidence packets.
+
+This is a local/tracker-side guard.  It does not touch Honey, launch OpenXR,
+or inspect live hardware.  It rejects P4 promotion claims unless the packet
+contains the explicit human-observation gate fields emitted by
+exwm-vr-openxr-smoke.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+
+FIELD_RE = re.compile(r"^\s*(?:[-*]\s*)?(.+?)\s*(?::|=)\s*(.*?)\s*$")
+PLACEHOLDERS = {
+    "",
+    "-",
+    "unset",
+    "unknown",
+    "todo",
+    "tbd",
+    "n/a",
+    "na",
+    "none",
+    "yes / no",
+    "yes / no / not observed",
+    "lab-observer",
+    "<observer>",
+    "<observer-id>",
+    "observer",
+}
+
+ALIASES = {
+    "lab_observer_at_honey": "visual_observer",
+    "observer": "visual_observer",
+    "confirmation_token_if_visual_observed_yes": "visual_confirmation",
+    "visible_non_black_output": "visible_non_black_output",
+}
+
+
+def normalize_key(raw: str) -> str:
+    key = raw.replace("`", "").strip().lower()
+    key = re.sub(r"\s+from wrapper$", "", key)
+    key = re.sub(r"[^a-z0-9]+", "_", key).strip("_")
+    return ALIASES.get(key, key)
+
+
+def clean_value(raw: str) -> str:
+    return raw.strip().strip("`").strip()
+
+
+def parse_fields(text: str) -> dict[str, list[str]]:
+    fields: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        match = FIELD_RE.match(line)
+        if not match:
+            continue
+        key = normalize_key(match.group(1))
+        value = clean_value(match.group(2))
+        fields.setdefault(key, []).append(value)
+    return fields
+
+
+def values(fields: dict[str, list[str]], key: str) -> list[str]:
+    return fields.get(key, [])
+
+
+def has_value(fields: dict[str, list[str]], key: str, expected: str) -> bool:
+    expected_lower = expected.lower()
+    return any(value.lower() == expected_lower for value in values(fields, key))
+
+
+def has_non_placeholder(fields: dict[str, list[str]], key: str) -> bool:
+    for value in values(fields, key):
+        normalized = value.strip().lower()
+        if normalized not in PLACEHOLDERS:
+            return True
+    return False
+
+
+def contains_value(fields: dict[str, list[str]], key: str, needle: str) -> bool:
+    needle_lower = needle.lower()
+    return any(needle_lower in value.lower() for value in values(fields, key))
+
+
+def p4_claimed(fields: dict[str, list[str]]) -> bool:
+    return (
+        has_value(fields, "visual_observed", "yes")
+        or has_value(fields, "visible_non_black_output", "yes")
+        or has_value(fields, "visual_first_frame", "P4_OBSERVED")
+        or contains_value(fields, "classification", "p4 pass")
+    )
+
+
+def validate(fields: dict[str, list[str]], require_p4: bool) -> list[str]:
+    errors: list[str] = []
+    claimed = p4_claimed(fields) or require_p4
+
+    if has_value(fields, "visual_first_frame", "P4_OBSERVED") and not has_value(
+        fields, "visual_observed", "yes"
+    ):
+        errors.append("visual_first_frame=P4_OBSERVED requires visual_observed=yes")
+
+    if contains_value(fields, "classification", "p4 pass") and (
+        has_value(fields, "visual_observed", "no")
+        or has_value(fields, "visual_observed", "not_observed")
+    ):
+        errors.append("P4 pass classification conflicts with visual_observed=no/not_observed")
+
+    if not claimed:
+        return errors
+
+    if not has_value(fields, "visual_observed", "yes"):
+        errors.append("P4 evidence requires visual_observed=yes")
+    if not has_non_placeholder(fields, "visual_observer"):
+        errors.append("P4 evidence requires a non-placeholder visual_observer")
+    if not has_value(fields, "visual_confirmation", "VISIBLE_NON_BLACK"):
+        errors.append("P4 evidence requires visual_confirmation=VISIBLE_NON_BLACK")
+    if not has_value(fields, "visual_first_frame", "P4_OBSERVED"):
+        errors.append("P4 evidence requires visual_first_frame=P4_OBSERVED")
+
+    return errors
+
+
+def read_input(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"ERROR: cannot read evidence packet {path}: {exc}", file=sys.stderr)
+        raise SystemExit(66) from exc
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Honey P4 visual first-frame evidence packets."
+    )
+    parser.add_argument(
+        "--require-p4",
+        action="store_true",
+        help="Require a complete P4 pass packet instead of only rejecting bad P4 claims.",
+    )
+    parser.add_argument(
+        "packet",
+        nargs="?",
+        default="-",
+        help="Evidence packet path, tracker draft path, or '-' for stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    fields = parse_fields(read_input(args.packet))
+    errors = validate(fields, args.require_p4)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 64
+
+    if args.require_p4 or p4_claimed(fields):
+        print("p4_evidence_check=passed")
+    else:
+        print("p4_evidence_check=no_p4_promotion_claim")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test/honey-substrate-test.el
+++ b/test/honey-substrate-test.el
@@ -49,6 +49,10 @@
   (expand-file-name "packaging/scripts/exwm-vr-openxr-smoke"
                     (expand-file-name ".." (file-name-directory load-file-name))))
 
+(defconst honey-substrate--p4-evidence-check-script
+  (expand-file-name "packaging/scripts/exwm-vr-p4-evidence-check"
+                    (expand-file-name ".." (file-name-directory load-file-name))))
+
 (defconst honey-substrate--hmd-connector-script
   (expand-file-name "packaging/scripts/exwm-vr-hmd-connector"
                     (expand-file-name ".." (file-name-directory load-file-name))))
@@ -162,6 +166,19 @@
       (let ((rc (apply #'call-process honey-substrate--openxr-smoke-script
                        nil (list t t) nil args)))
         (cons rc (buffer-string))))))
+
+(defun honey-substrate--run-p4-evidence-check (content &rest args)
+  "Run the P4 evidence checker against CONTENT with ARGS."
+  (let ((packet (make-temp-file "honey-p4-evidence-" nil ".md")))
+    (unwind-protect
+        (progn
+          (write-region content nil packet nil 'silent)
+          (with-temp-buffer
+            (let ((rc (apply #'call-process honey-substrate--p4-evidence-check-script
+                             nil (list t t) nil
+                             (append args (list packet)))))
+              (cons rc (buffer-string)))))
+      (delete-file packet))))
 
 (ert-deftest honey-substrate/beyond-first-frame-sets-runtime-dir ()
   "beyond-first-frame uses a real runtime dir for remote OpenXR client tools."
@@ -279,6 +296,43 @@
             (should (string-match-p "visual_confirmation=VISIBLE_NON_BLACK" (cdr observed)))
             (should (string-match-p "visual_first_frame=P4_OBSERVED" (cdr observed)))))
       (delete-directory root t))))
+
+(ert-deftest honey-substrate/p4-evidence-checker-rejects-ungated-promotion ()
+  "A tracker-side P4 claim should require the same gate as the wrapper."
+  (let ((result
+         (honey-substrate--run-p4-evidence-check
+          (concat "Honey P4 visual-first-frame evidence:\n\n"
+                  "- visual_observed: yes\n"
+                  "- visual_first_frame: P4_OBSERVED\n"
+                  "- classification: P4 pass: visible non-black first frame observed\n"))))
+    (should (= (car result) 64))
+    (should (string-match-p "visual_observer" (cdr result)))
+    (should (string-match-p "VISIBLE_NON_BLACK" (cdr result)))))
+
+(ert-deftest honey-substrate/p4-evidence-checker-accepts-complete-p4-packet ()
+  "Complete observed visual evidence should pass the strict P4 checker mode."
+  (let ((result
+         (honey-substrate--run-p4-evidence-check
+          (concat "Honey P4 visual-first-frame evidence:\n\n"
+                  "- `visual_observed` from wrapper: yes\n"
+                  "- `visual_observer` from wrapper: lab-jess\n"
+                  "- `visual_confirmation` from wrapper: VISIBLE_NON_BLACK\n"
+                  "- `visual_first_frame` from wrapper: P4_OBSERVED\n"
+                  "- classification: P4 pass: visible non-black first frame observed\n")
+          "--require-p4")))
+    (should (= (car result) 0))
+    (should (string-match-p "p4_evidence_check=passed" (cdr result)))))
+
+(ert-deftest honey-substrate/p4-evidence-checker-allows-p3-fail-packet ()
+  "P3 pass/P4 fail evidence should remain postable without P4 promotion."
+  (let ((result
+         (honey-substrate--run-p4-evidence-check
+          (concat "Honey P4 visual-first-frame evidence:\n\n"
+                  "- visual_observed: no\n"
+                  "- visual_first_frame: P4_UNOBSERVED\n"
+                  "- classification: P3 pass / P4 fail: focused OpenXR session, black headset\n"))))
+    (should (= (car result) 0))
+    (should (string-match-p "p4_evidence_check=no_p4_promotion_claim" (cdr result)))))
 
 (ert-deftest honey-substrate/connector-resolver-prefers-nondesktop-dp ()
   "The HMD resolver prefers a connected DP connector with non_desktop=1."

--- a/test/truth-surface-test.el
+++ b/test/truth-surface-test.el
@@ -312,7 +312,9 @@
         (template (truth-surface-test--read-file "docs/honey-fresh-boot-evidence-template.md"))
         (p4-template (truth-surface-test--read-file
                       "docs/honey-p4-visual-first-frame-evidence-template.md"))
-        (smoke (truth-surface-test--read-file "packaging/scripts/exwm-vr-openxr-smoke")))
+        (smoke (truth-surface-test--read-file "packaging/scripts/exwm-vr-openxr-smoke"))
+        (p4-checker (truth-surface-test--read-file
+                     "packaging/scripts/exwm-vr-p4-evidence-check")))
     (dolist (level '("P0 Inventory"
                      "P1 Host Substrate"
                      "P2 Lease/Runtime"
@@ -340,12 +342,17 @@
     (should (string-match-p "EXWM_VR_VISUAL_CONFIRMATION=VISIBLE_NON_BLACK" p4-template))
     (should (string-match-p "visual_observer" p4-template))
     (should (string-match-p "visual_confirmation" p4-template))
+    (should (string-match-p "honey-p4-evidence-check" p4-template))
+    (should (string-match-p "--require-p4" p4-template))
     (should (string-match-p "P3 pass / P4 fail" p4-template))
     (should (string-match-p "P5" p4-template))
     (should (string-match-p "Do not stop, restart, drain, or otherwise touch `rke2`" p4-template))
     (should (string-match-p "not P4 unless a human records visible" p4-template))
     (should (string-match-p "proof_ladder=P3_OPENXR_SESSION" smoke))
     (should (string-match-p "openxr_smoke=p3_session_after_ready_timeout" smoke))
+    (should (string-match-p "visual_first_frame=P4_OBSERVED" p4-checker))
+    (should (string-match-p "visual_confirmation=VISIBLE_NON_BLACK" p4-checker))
+    (should (string-match-p "P4 pass classification conflicts" p4-checker))
     (should-not (string-match-p "passed_after_ready_timeout" smoke))
     (should-not (string-match-p "first frame confirmed" smoke))))
 


### PR DESCRIPTION
## Summary

- add a local `exwm-vr-p4-evidence-check` packet/tracker-draft checker for Honey P4 visual-first-frame evidence
- expose it as `just honey-p4-evidence-check`
- update the P4 template and tests so tracker promotion claims require the same observer/token/P4 fields as the OpenXR smoke wrapper

## Tracker

- Refs #49
- Linear: TIN-1086

## Validation

- `git diff --check`
- `python3 -m py_compile packaging/scripts/exwm-vr-p4-evidence-check`
- `emacs --batch -L /Users/jess/git/XoxdWM/lisp/core -L /Users/jess/git/XoxdWM/lisp/vr -L /Users/jess/git/XoxdWM/lisp/ext --eval '(setq ewwm-test-selector "^honey-substrate/")' -l /Users/jess/git/XoxdWM/test/run-tests.el`
- `just truth-lint`
- `just honey-p4-evidence-check -` with a complete stdin P4 packet

No Honey host, OpenXR hardware, services, debugfs, reboot, or `rke2` path was touched.
