### PR TITLE
Refresh CI action pins

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,26 +1,26 @@
 name: Setup sccache
-description: Configure sccache for Rust builds with GHA cache backend (soft dependency)
+description: Configure sccache for Rust builds when the GHA cache backend is available
 
 runs:
   using: composite
   steps:
-    - uses: mozilla-actions/sccache-action@v0.0.6
+    - uses: mozilla-actions/sccache-action@v0.0.10
       continue-on-error: true
       id: sccache
 
     - name: Configure sccache environment
       shell: bash
       run: |
-        # Only set RUSTC_WRAPPER if sccache is available and functional
+        # Only set RUSTC_WRAPPER if sccache is available and functional.
         if command -v sccache &>/dev/null && sccache --version &>/dev/null; then
-          # Verify the cache backend is reachable
+          # The cache is an accelerator, not a CI authority signal.
           if SCCACHE_GHA_ENABLED=true sccache rustc -vV &>/dev/null; then
             echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
             echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
             echo "::notice::sccache enabled with GHA cache backend"
           else
-            echo "::warning::sccache cache backend unreachable — building without cache"
+            echo "::notice::sccache cache backend unavailable; building without cache"
           fi
         else
-          echo "::warning::sccache not available — building without cache"
+          echo "::notice::sccache not available; building without cache"
         fi

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:

--- a/.github/workflows/chapel-ci.yml
+++ b/.github/workflows/chapel-ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Mason dependencies
         working-directory: analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Byte-compile all Elisp
         run: nix develop --command just build
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Run ERT test suite
         run: nix develop --command just test
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Lint Elisp (strict byte-compile)
         run: nix develop --command just lint-elisp
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Run truth-surface checks
         run: nix develop --command just truth-lint
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Check flake evaluates
         run: nix flake check --no-build
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v30
       - name: Validate Dhall boot types and configs
         run: |
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: cachix/install-nix-action@v30

--- a/.github/workflows/monado-companion.yml
+++ b/.github/workflows/monado-companion.yml
@@ -22,7 +22,7 @@ jobs:
     container: rockylinux/rockylinux:10
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install rpmbuild dependencies
         run: |

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -109,7 +109,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -136,7 +136,7 @@ jobs:
     timeout-minutes: 25
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -180,7 +180,7 @@ jobs:
     timeout-minutes: 25
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: DeterminateSystems/nix-installer-action@v16
         with:

--- a/.github/workflows/native-deps.yml
+++ b/.github/workflows/native-deps.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -80,7 +80,7 @@ jobs:
       PATH: /usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       CCACHE_DIR: /root/.ccache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:

--- a/.github/workflows/openxr-smoke-client.yml
+++ b/.github/workflows/openxr-smoke-client.yml
@@ -24,7 +24,7 @@ jobs:
     container: rockylinux/rockylinux:10
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install rpmbuild dependencies
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set version
         id: version
@@ -69,7 +69,7 @@ jobs:
     container: rockylinux/rockylinux:10
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install rpmbuild dependencies
         run: |
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install FPM
         run: |

--- a/.github/workflows/rocky-test.yml
+++ b/.github/workflows/rocky-test.yml
@@ -27,7 +27,7 @@ jobs:
       CARGO_HOME: /root/.cargo
       PATH: /root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install build dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
       PATH: /root/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       NIX_SSL_CERT_FILE: /etc/pki/tls/certs/ca-bundle.crt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Nix (single-user)
         run: |

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ vars.USE_SELFHOSTED == 'true' && vars.GF_SHARED_RUNNERS_REACHABLE == 'true' && 'tinyland-nix' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:

--- a/.github/workflows/self-hosted-fast.yml
+++ b/.github/workflows/self-hosted-fast.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -100,7 +100,7 @@ jobs:
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -145,7 +145,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync repository labels
         uses: actions/github-script@v7

--- a/.github/workflows/vr-hardware.yml
+++ b/.github/workflows/vr-hardware.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check GPU
         run: |
@@ -64,7 +64,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -94,7 +94,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -136,7 +136,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -174,7 +174,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:
@@ -220,7 +220,7 @@ jobs:
     runs-on: [self-hosted, honey]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/ensure-nix
         with:

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,6 +1,6 @@
 # XoxdWM Status
 
-Snapshot date: 2026-05-12
+Snapshot date: 2026-05-13
 
 ## Honest Assessment
 
@@ -52,10 +52,15 @@ Snapshot date: 2026-05-12
   - `nix flake check --no-build` passes locally
   - local byte-compile and headless Rust checks can pass, but they are auxiliary repo-maintenance checks rather than the default build authority path
   - this does not turn macOS into a supported runtime target; it only reduces local repo-management friction
-- Recent push CI failures were concentrated in three places:
-  - Rocky test: optional `sccache` setup step
-  - Nix cache workflow: attempting to install Nix on a pre-provisioned self-hosted runner
-  - self-hosted fast CI: heavy checks on all pushes, including non-code work
+- Current #11 CI hygiene separates build/product failures from runner and cache
+  substrate state:
+  - workflow checkout steps use the Node 24-compatible `actions/checkout@v6`
+    line instead of the deprecated Node 20-era `actions/checkout@v4` pin
+  - the optional `sccache` setup remains a soft accelerator; if the GHA cache
+    backend is unavailable, workflows continue without treating that cache miss
+    as product or runner failure evidence
+  - Nix cache and self-hosted fast lanes still only select shared
+    `tinyland-nix` after `GF_SHARED_RUNNERS_REACHABLE=true`
 - Shared self-hosted CI is being reconciled against the GloriousFlywheel runner
   contract:
   - `Jesssullivan/XoxdWM#29` removed the shared-path fork gate and passed on an ephemeral `xoxdwm-nix` runner; merged PR #34 migrated non-hardware self-hosted jobs to the shared `tinyland-nix` capability lane

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -113,7 +113,7 @@ acquisition proof or promote product support.
 
 | Workflow Area | Status | Notes |
 | --- | --- | --- |
-| Lightweight CI on code changes | Smoke | Kept as primary CI surface. |
+| Lightweight CI on code changes | Smoke | Kept as primary CI surface. Workflow checkout pins track the Node 24-compatible `actions/checkout@v6` line, and optional cache accelerators such as `sccache` remain non-authority hints rather than product-failure evidence. |
 | Rocky Linux test | Smoke | Workflow exists and the current branch proof lane is green: run `24776895510` passed both `Rocky Linux 10 Build & Test` and `Rocky Linux 10 + Nix` on `2026-04-22`. |
 | Self-hosted fast CI | Smoke | The stale `xoxdwm-nix` repo-shaped lane is no longer treated as current authority. Self-hosted Nix workflows target the shared `tinyland-nix` GloriousFlywheel capability lane only when both `USE_SELFHOSTED` and `GF_SHARED_RUNNERS_REACHABLE` are true; otherwise they fall back to hosted Linux or skip self-hosted-only jobs while enrollment/scheduling is tracked separately from product proof. |
 | VR hardware-in-the-loop CI | Design | Honey-backed jobs now require explicit `USE_VR_HARDWARE=true` instead of a fork-shaped repo-name gate. The lane is not yet claimed as active on the canonical repo by default. |

--- a/test/truth-surface-test.el
+++ b/test/truth-surface-test.el
@@ -27,6 +27,14 @@
     (insert-file-contents (expand-file-name relative truth-surface-test--root))
     (buffer-string)))
 
+(defun truth-surface-test--github-yaml-files ()
+  "Return repo-relative GitHub workflow/action YAML files."
+  (mapcar
+   (lambda (file) (file-relative-name file truth-surface-test--root))
+   (directory-files-recursively
+    (expand-file-name ".github" truth-surface-test--root)
+    "\\.ya?ml\\'")))
+
 (defun truth-surface-test--dispatch-command-count ()
   "Count explicit IPC commands in the dispatcher."
   (let ((count 0))
@@ -116,6 +124,27 @@
     (should-not
      (string-match-p "magic-nix-cache-action"
                      (truth-surface-test--read-file relative)))))
+
+(ert-deftest truth-surface/ci-actions-avoid-node20-deprecated-pins ()
+  "GitHub Action pins should stay compatible with the Node 24 runtime floor."
+  (let ((saw-checkout nil))
+    (dolist (relative (truth-surface-test--github-yaml-files))
+      (let ((content (truth-surface-test--read-file relative)))
+        (should-not (string-match-p "actions/checkout@v4" content))
+        (when (string-match-p "actions/checkout@" content)
+          (setq saw-checkout t)
+          (should (string-match-p "actions/checkout@v6" content)))))
+    (should saw-checkout))
+  (let ((sccache (truth-surface-test--read-file
+                  ".github/actions/setup-sccache/action.yml")))
+    (should (string-match-p
+             "mozilla-actions/sccache-action@v0\\.0\\.10"
+             sccache))
+    (should (string-match-p "continue-on-error: true" sccache))
+    (should (string-match-p
+             "sccache cache backend unavailable; building without cache"
+             sccache))
+    (should-not (string-match-p "::warning::sccache" sccache))))
 
 (ert-deftest truth-surface/readme-links-remote-build-authority ()
   "README should link the explicit remote-build authority doc."


### PR DESCRIPTION
## Summary

- Move live GitHub workflow checkout steps to `actions/checkout@v6`.
- Update the shared sccache composite action to `mozilla-actions/sccache-action@v0.0.10`.
- Keep sccache as an optional accelerator by downgrading unavailable-cache messages to notices instead of warnings.
- Add truth-surface coverage so live workflow/action YAML does not drift back to deprecated checkout pins or warning-shaped sccache fallback.
- Update CI truth docs for the #11 runner/cache boundary.

Refs #11.
Refs TIN-592.

## Validation

- `git diff --check`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml .github/actions/*/action.yml`
- `emacs --batch -L test -l ert -l test/truth-surface-test.el --eval '(ert-run-tests-batch-and-exit "truth-surface/ci-actions-avoid-node20-deprecated-pins")'`
- `just truth-lint`
- `just test`

## Boundary

#11 remains open for the broader shared-runner reachability contract. This PR only removes current action-runtime deprecation and optional-cache noise from the live workflow surface.
