### PR TITLE
Pin Nix installer action to Node 24 runtime

### DIFF
--- a/.github/actions/ensure-nix/action.yml
+++ b/.github/actions/ensure-nix/action.yml
@@ -32,7 +32,9 @@ runs:
 
     - name: Install Nix on self-hosted runners
       if: ${{ inputs.self_hosted == 'true' }}
-      uses: DeterminateSystems/nix-installer-action@main
+      uses: DeterminateSystems/nix-installer-action@v22
+      with:
+        determinate: false
 
     - name: Setup cache hints
       shell: bash

--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -11,6 +11,7 @@ on:
       - 'nix/**'
       - 'flake.nix'
       - 'flake.lock'
+      - '.github/actions/**'
       - '.github/workflows/multi-arch.yml'
   pull_request:
     branches: [main, dev]
@@ -21,6 +22,7 @@ on:
       - 'nix/**'
       - 'flake.nix'
       - 'flake.lock'
+      - '.github/actions/**'
       - '.github/workflows/multi-arch.yml'
 
 concurrency:
@@ -220,8 +222,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
+          determinate: false
           extra-conf: |
             system-features = kvm nixos-test
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -57,6 +57,12 @@ Snapshot date: 2026-05-13
   substrate state:
   - workflow checkout steps use the Node 24-compatible `actions/checkout@v6`
     line instead of the deprecated Node 20-era `actions/checkout@v4` pin
+  - Determinate Nix installer steps use the Node 24-compatible
+    `DeterminateSystems/nix-installer-action@v22` pin with
+    `determinate: false` set explicitly, so the runtime upgrade does not
+    silently change installer flavor
+  - the Multi-Architecture workflow reruns when shared `.github/actions/**`
+    helpers change, not only when the workflow YAML itself changes
   - the optional `sccache` setup remains a soft accelerator; if the GHA cache
     backend is unavailable, workflows continue without treating that cache miss
     as product or runner failure evidence

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -113,7 +113,7 @@ acquisition proof or promote product support.
 
 | Workflow Area | Status | Notes |
 | --- | --- | --- |
-| Lightweight CI on code changes | Smoke | Kept as primary CI surface. Workflow checkout pins track the Node 24-compatible `actions/checkout@v6` line, and optional cache accelerators such as `sccache` remain non-authority hints rather than product-failure evidence. |
+| Lightweight CI on code changes | Smoke | Kept as primary CI surface. Workflow checkout and Nix installer pins track Node 24-compatible action lines, shared `.github/actions/**` helper changes trigger the Multi-Architecture workflow, and optional cache accelerators such as `sccache` remain non-authority hints rather than product-failure evidence. |
 | Rocky Linux test | Smoke | Workflow exists and the current branch proof lane is green: run `24776895510` passed both `Rocky Linux 10 Build & Test` and `Rocky Linux 10 + Nix` on `2026-04-22`. |
 | Self-hosted fast CI | Smoke | The stale `xoxdwm-nix` repo-shaped lane is no longer treated as current authority. Self-hosted Nix workflows target the shared `tinyland-nix` GloriousFlywheel capability lane only when both `USE_SELFHOSTED` and `GF_SHARED_RUNNERS_REACHABLE` are true; otherwise they fall back to hosted Linux or skip self-hosted-only jobs while enrollment/scheduling is tracked separately from product proof. `just runner-reachability-truth` is the read-only classifier for this boundary and does not promote hosted fallback, `runner_name=null`, or recreated `xoxdwm-*` runners to proof. |
 | VR hardware-in-the-loop CI | Design | Honey-backed jobs now require explicit `USE_VR_HARDWARE=true` instead of a fork-shaped repo-name gate. The lane is not yet claimed as active on the canonical repo by default. |

--- a/test/truth-surface-test.el
+++ b/test/truth-surface-test.el
@@ -127,14 +127,30 @@
 
 (ert-deftest truth-surface/ci-actions-avoid-node20-deprecated-pins ()
   "GitHub Action pins should stay compatible with the Node 24 runtime floor."
-  (let ((saw-checkout nil))
+  (let ((saw-checkout nil)
+        (saw-determinate-nix nil))
     (dolist (relative (truth-surface-test--github-yaml-files))
       (let ((content (truth-surface-test--read-file relative)))
         (should-not (string-match-p "actions/checkout@v4" content))
         (when (string-match-p "actions/checkout@" content)
           (setq saw-checkout t)
-          (should (string-match-p "actions/checkout@v6" content)))))
-    (should saw-checkout))
+          (should (string-match-p "actions/checkout@v6" content)))
+        (should-not
+         (string-match-p "DeterminateSystems/nix-installer-action@v16" content))
+        (should-not
+         (string-match-p "DeterminateSystems/nix-installer-action@main" content))
+        (when (string-match-p "DeterminateSystems/nix-installer-action@"
+                              content)
+          (setq saw-determinate-nix t)
+          (should
+           (string-match-p "DeterminateSystems/nix-installer-action@v22"
+                           content))
+          (should (string-match-p "determinate: false" content)))))
+    (should saw-checkout)
+    (should saw-determinate-nix))
+  (let ((multi-arch (truth-surface-test--read-file
+                     ".github/workflows/multi-arch.yml")))
+    (should (string-match-p "\\.github/actions/\\*\\*" multi-arch)))
   (let ((sccache (truth-surface-test--read-file
                   ".github/actions/setup-sccache/action.yml")))
     (should (string-match-p


### PR DESCRIPTION
## Summary
- Pin Determinate nix-installer-action use to the Node 24-compatible v22 release.
- Preserve existing non-Determinate installer behavior with explicit `determinate: false`.
- Make Multi-Architecture rerun on shared `.github/actions/**` helper changes and add a truth guard for the pins.

## Tracker
Refs #11. Shared `tinyland-nix` assigned-runner proof remains the issue exit gate.

## Validation
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }; puts "yaml_parse=passed"' .github/workflows/*.yml .github/actions/*/action.yml`\n- `emacs --batch -L lisp/core -L lisp/vr -L lisp/ext --eval '(setq ewwm-test-selector "truth-surface/ci-actions-avoid-node20-deprecated-pins")' -l test/run-tests.el`\n- `just truth-lint`\n- `just test`\n- `git diff --check`