### PR TITLE
Handle Yoga DRM probing and seat input repeatability

### DIFF
--- a/compositor/src/backend/drm.rs
+++ b/compositor/src/backend/drm.rs
@@ -764,6 +764,19 @@ fn render_output(gpu: &mut GpuDevice, crtc: crtc::Handle, state: &mut EwwmState)
     }
 }
 
+/// Render every configured DRM output.
+fn render_all_outputs(backend: &mut DrmBackendData, state: &mut EwwmState) {
+    let nodes: Vec<DrmNode> = backend.devices.keys().copied().collect();
+    for node in nodes {
+        if let Some(gpu) = backend.devices.get_mut(&node) {
+            let crtcs: Vec<crtc::Handle> = gpu.outputs.keys().copied().collect();
+            for crtc in crtcs {
+                render_output(gpu, crtc, state);
+            }
+        }
+    }
+}
+
 /// Handle a vblank event from a calloop DRM source callback.
 ///
 /// Since the calloop callback only receives `&mut EwwmState` (not the
@@ -1206,12 +1219,7 @@ pub fn run(
     // ── 12. Initial render for all outputs ────────────────────────────
 
     // Kick off the first frame on every output.
-    for (_node, gpu) in backend_data.devices.iter_mut() {
-        let crtcs: Vec<crtc::Handle> = gpu.outputs.keys().copied().collect();
-        for crtc in crtcs {
-            render_output(gpu, crtc, &mut state);
-        }
-    }
+    render_all_outputs(&mut backend_data, &mut state);
 
     info!("DRM backend initialized, entering event loop");
 
@@ -1278,6 +1286,10 @@ pub fn run(
         // Dispatch and flush pending Wayland client events.
         display.dispatch_clients(&mut state)?;
         display.flush_clients()?;
+
+        if state.take_render_request() {
+            render_all_outputs(&mut backend_data, &mut state);
+        }
     }
 
     // ── 14. Cleanup ───────────────────────────────────────────────────

--- a/compositor/src/backend/drm.rs
+++ b/compositor/src/backend/drm.rs
@@ -204,6 +204,28 @@ fn device_added(
         .map_err(|e| anyhow::anyhow!("DrmDevice::new failed: {}", e))?;
     let drm = Rc::new(RefCell::new(drm));
 
+    // Hybrid laptops can expose render/offload GPUs with no scanout connectors.
+    // Avoid initializing GBM/EGL on those devices before the real display GPU.
+    let connector_count = match drm.borrow().resource_handles() {
+        Ok(resources) => resources.connectors().len(),
+        Err(e) => {
+            warn!(
+                ?path,
+                ?node,
+                "failed to read DRM connectors before renderer init: {}", e
+            );
+            0
+        }
+    };
+    if connector_count == 0 {
+        info!(
+            ?path,
+            ?node,
+            "DRM device has no connectors, skipping renderer initialization"
+        );
+        return Ok(());
+    }
+
     // Create GBM device on the same fd.
     let gbm = GbmDevice::new(drm_fd.clone())
         .map_err(|e| anyhow::anyhow!("GbmDevice::new failed: {}", e))?;

--- a/compositor/src/handlers/compositor.rs
+++ b/compositor/src/handlers/compositor.rs
@@ -51,6 +51,8 @@ impl CompositorHandler for EwwmState {
                 }
             }
         }
+
+        self.request_render();
     }
 }
 

--- a/compositor/src/input.rs
+++ b/compositor/src/input.rs
@@ -14,7 +14,7 @@ use smithay::{
     },
     utils::SERIAL_COUNTER,
 };
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// Handle an input event from any backend.
 pub fn handle_input<B: InputBackend>(state: &mut EwwmState, event: InputEvent<B>) {
@@ -69,7 +69,10 @@ fn handle_keyboard<B: InputBackend>(state: &mut EwwmState, event: B::KeyboardKey
     let keycode = event.key_code();
     let key_state = event.state();
 
-    let keyboard = state.seat.get_keyboard().unwrap();
+    let Some(keyboard) = state.seat.get_keyboard() else {
+        warn!("keyboard input received before keyboard capability was initialized");
+        return;
+    };
 
     // Check for grabbed keys
     let _grab_result = keyboard.input::<bool, _>(
@@ -122,11 +125,17 @@ fn handle_pointer_motion_absolute<B: InputBackend>(
 ) {
     let output = state.space.outputs().next().cloned();
     if let Some(output) = output {
-        let output_geo = state.space.output_geometry(&output).unwrap();
+        let Some(output_geo) = state.space.output_geometry(&output) else {
+            warn!("pointer motion received for output without geometry");
+            return;
+        };
         let pos = event.position_transformed(output_geo.size);
 
         let serial = SERIAL_COUNTER.next_serial();
-        let pointer = state.seat.get_pointer().unwrap();
+        let Some(pointer) = state.seat.get_pointer() else {
+            warn!("pointer motion received before pointer capability was initialized");
+            return;
+        };
 
         // Find surface under pointer for focus
         let surface_under = state.space.element_under(pos).map(|(w, loc)| {
@@ -155,7 +164,10 @@ fn handle_pointer_button<B: InputBackend>(state: &mut EwwmState, event: B::Point
     let button = event.button_code();
     let button_state = event.state();
 
-    let pointer = state.seat.get_pointer().unwrap();
+    let Some(pointer) = state.seat.get_pointer() else {
+        warn!("pointer button received before pointer capability was initialized");
+        return;
+    };
     pointer.button(
         state,
         &ButtonEvent {
@@ -182,7 +194,10 @@ fn handle_pointer_axis<B: InputBackend>(state: &mut EwwmState, event: B::Pointer
     let horizontal = event.amount(Axis::Horizontal).unwrap_or(0.0);
     let vertical = event.amount(Axis::Vertical).unwrap_or(0.0);
 
-    let pointer = state.seat.get_pointer().unwrap();
+    let Some(pointer) = state.seat.get_pointer() else {
+        warn!("pointer axis received before pointer capability was initialized");
+        return;
+    };
     let mut frame = AxisFrame::new(Event::time_msec(&event) as u32).source(source);
     if horizontal != 0.0 {
         frame = frame.value(Axis::Horizontal, horizontal);

--- a/compositor/src/state.rs
+++ b/compositor/src/state.rs
@@ -263,6 +263,7 @@ pub struct EwwmState {
 
     // Shutdown flag
     pub running: bool,
+    render_requested: bool,
 
     // Clock (real or test)
     pub clock: Arc<dyn Clock>,
@@ -416,6 +417,7 @@ impl EwwmState {
             focused_surface: None,
             cursor_status: CursorImageStatus::Default,
             running: true,
+            render_requested: false,
             clock: Arc::new(SystemClock),
         }
     }
@@ -464,6 +466,16 @@ impl EwwmState {
         self.surface_to_window.get(&surface_id)
     }
 
+    pub fn request_render(&mut self) {
+        self.render_requested = true;
+    }
+
+    pub fn take_render_request(&mut self) -> bool {
+        let requested = self.render_requested;
+        self.render_requested = false;
+        requested
+    }
+
     /// Initial visible rectangle for newly mapped application windows.
     pub fn initial_window_geometry(&self) -> Rectangle<i32, Logical> {
         let area = self.usable_area;
@@ -491,6 +503,7 @@ impl EwwmState {
                 let _ = x11.configure(Some(geometry));
             }
         }
+        self.request_render();
     }
 
     pub fn apply_workspace_visibility(&mut self) {
@@ -538,6 +551,7 @@ impl EwwmState {
             .collect();
         tiled.sort_unstable();
         if tiled.is_empty() {
+            self.request_render();
             return;
         }
 
@@ -545,6 +559,7 @@ impl EwwmState {
         for (surface_id, geometry) in tiled.into_iter().zip(rects) {
             self.set_surface_geometry(surface_id, geometry);
         }
+        self.request_render();
     }
 
     fn layout_rects(&self, count: usize) -> Vec<Rectangle<i32, Logical>> {
@@ -812,6 +827,7 @@ impl EwwmState {
                     keyboard.set_focus(self, Some(surface), serial);
                 }
             }
+            self.request_render();
         }
     }
 
@@ -850,4 +866,24 @@ pub struct ClientState {
 impl ClientData for ClientState {
     fn initialized(&self, _client_id: ClientId) {}
     fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::reexports::calloop::EventLoop;
+
+    #[test]
+    fn render_request_latches_until_taken() {
+        let event_loop = EventLoop::<EwwmState>::try_new().unwrap();
+        let mut display = Display::<EwwmState>::new().unwrap();
+        let mut state = EwwmState::new(&mut display, event_loop.handle());
+
+        assert!(!state.take_render_request());
+
+        state.request_render();
+
+        assert!(state.take_render_request());
+        assert!(!state.take_render_request());
+    }
 }

--- a/compositor/src/state.rs
+++ b/compositor/src/state.rs
@@ -332,7 +332,10 @@ impl EwwmState {
         // Pointer constraints (pointer-constraints-unstable-v1)
         let pointer_constraints_state = PointerConstraintsState::new::<Self>(&display_handle);
 
-        let seat = seat_state.new_wl_seat(&display_handle, "ewwm-seat");
+        let mut seat = seat_state.new_wl_seat(&display_handle, "ewwm-seat");
+        seat.add_keyboard(Default::default(), 200, 25)
+            .expect("failed to initialize keyboard capability");
+        seat.add_pointer();
 
         info!(
             "EwwmState initialized (layer-shell, foreign-toplevel, session-lock, \

--- a/docs/honey-fresh-boot-evidence-template.md
+++ b/docs/honey-fresh-boot-evidence-template.md
@@ -95,7 +95,8 @@ CLI smoke is not first-frame proof by itself.
 - Headset/display note:
 - Confirmation token if `visual_observed=yes`:
 - If no visible frame, record `visual_observed=no` and classify as P3 pass /
-  P4 fail even if CLI smoke reached `FOCUSED`.
+  P4 fail with `visual_first_frame=P4_FAILED` even if CLI smoke reached
+  `FOCUSED`.
 
 ## Kernel / DSC PPS Evidence
 

--- a/docs/honey-p4-visual-first-frame-evidence-template.md
+++ b/docs/honey-p4-visual-first-frame-evidence-template.md
@@ -138,8 +138,9 @@ Select exactly one:
 
 - `visual_observed=yes`: visible non-black headset output was observed.
 - `visual_observed=no`: OpenXR/Monado reached session proof, but the goggles
-  stayed black.
+  stayed black. The wrapper should report `visual_first_frame=P4_FAILED`.
 - `visual_observed=not_observed`: no person was watching the headset.
+  The wrapper should report `visual_first_frame=P4_UNOBSERVED`.
 
 Required fields:
 

--- a/docs/honey-pps-diagnostic-runbook-2026-05-12.md
+++ b/docs/honey-pps-diagnostic-runbook-2026-05-12.md
@@ -133,8 +133,9 @@ Record the human-visible result separately:
 - `visual_observed=yes`: visible non-black HMD output was observed by the lab
   operator during the active run.
 - `visual_observed=no`: OpenXR/Monado reached session proof but goggles stayed
-  black.
+  black. Record `visual_first_frame=P4_FAILED`.
 - `visual_observed=not_observed`: no person was watching the headset.
+  Record `visual_first_frame=P4_UNOBSERVED`.
 
 Do not promote #49 unless `visual_observed=yes` is backed by an attended
 evidence packet.

--- a/packaging/scripts/exwm-vr-openxr-smoke
+++ b/packaging/scripts/exwm-vr-openxr-smoke
@@ -100,6 +100,14 @@ validate_visual_observation() {
 
 validate_visual_observation
 
+visual_first_frame_status() {
+    case "$visual_observed" in
+        yes) echo "P4_OBSERVED" ;;
+        no) echo "P4_FAILED" ;;
+        not_observed) echo "P4_UNOBSERVED" ;;
+    esac
+}
+
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 export XR_RUNTIME_JSON="${XR_RUNTIME_JSON:-/etc/xdg/openxr/1/active_runtime.json}"
 
@@ -273,7 +281,7 @@ if ((rc == 0)); then
         echo "visual_confirmation=${visual_confirmation}"
         echo "visual_first_frame=P4_OBSERVED"
     else
-        echo "visual_first_frame=P4_UNOBSERVED"
+        echo "visual_first_frame=$(visual_first_frame_status)"
     fi
     exit 0
 fi
@@ -283,7 +291,7 @@ if ((rc == 124)) && [[ "$accept_timeout_after_ready" = "1" ]]; then
         echo "openxr_smoke=p3_session_after_ready_timeout"
         echo "proof_ladder=P3_OPENXR_SESSION"
         echo "visual_observed=${visual_observed}"
-        echo "visual_first_frame=P4_UNOBSERVED"
+        echo "visual_first_frame=$(visual_first_frame_status)"
         exit 0
     fi
 fi

--- a/test/compositor-test.el
+++ b/test/compositor-test.el
@@ -44,6 +44,31 @@
   (should (file-exists-p
            (expand-file-name "compositor/src/render.rs" compositor-test--root))))
 
+(ert-deftest compositor-test/drm-repaints-after-surface-changes ()
+  "DRM backend drains render requests raised by surface changes."
+  (let ((state-rs (expand-file-name "compositor/src/state.rs" compositor-test--root))
+        (compositor-rs
+         (expand-file-name "compositor/src/handlers/compositor.rs"
+                           compositor-test--root))
+        (drm-rs (expand-file-name "compositor/src/backend/drm.rs"
+                                   compositor-test--root)))
+    (dolist (file (list state-rs compositor-rs drm-rs))
+      (should (file-exists-p file)))
+    (with-temp-buffer
+      (insert-file-contents state-rs)
+      (let ((source (buffer-string)))
+        (should (string-match-p "render_requested: bool" source))
+        (should (string-match-p "pub fn request_render" source))
+        (should (string-match-p "pub fn take_render_request" source))))
+    (with-temp-buffer
+      (insert-file-contents compositor-rs)
+      (should (string-match-p "self\\.request_render();" (buffer-string))))
+    (with-temp-buffer
+      (insert-file-contents drm-rs)
+      (let ((source (buffer-string)))
+        (should (string-match-p "fn render_all_outputs" source))
+        (should (string-match-p "state\\.take_render_request()" source))))))
+
 (ert-deftest compositor-test/rust-toolchain-exists ()
   (should (file-exists-p
            (expand-file-name "compositor/rust-toolchain.toml" compositor-test--root))))

--- a/test/honey-substrate-test.el
+++ b/test/honey-substrate-test.el
@@ -256,7 +256,8 @@
       (should (string-match-p (regexp-quote "EXWM_VR_VISUAL_CONFIRMATION=VISIBLE_NON_BLACK") script))
       (should (string-match-p (regexp-quote "EXWM_VR_VISUAL_OBSERVED=yes requires EXWM_VR_VISUAL_OBSERVER") script))
       (should (string-match-p (regexp-quote "visual_first_frame=P4_OBSERVED") script))
-      (should (string-match-p (regexp-quote "visual_first_frame=P4_UNOBSERVED") script))
+      (should (string-match-p (regexp-quote "P4_FAILED") script))
+      (should (string-match-p (regexp-quote "P4_UNOBSERVED") script))
       (should-not (string-match-p (regexp-quote "first frame confirmed") script)))))
 
 (ert-deftest honey-substrate/openxr-smoke-requires-human-confirmation-for-p4 ()
@@ -329,7 +330,7 @@
          (honey-substrate--run-p4-evidence-check
           (concat "Honey P4 visual-first-frame evidence:\n\n"
                   "- visual_observed: no\n"
-                  "- visual_first_frame: P4_UNOBSERVED\n"
+                  "- visual_first_frame: P4_FAILED\n"
                   "- classification: P3 pass / P4 fail: focused OpenXR session, black headset\n"))))
     (should (= (car result) 0))
     (should (string-match-p "p4_evidence_check=no_p4_promotion_claim" (cdr result)))))


### PR DESCRIPTION
## Summary

- skip DRM devices with no scanout connectors before GBM/EGL/GLES renderer initialization
- initialize Smithay keyboard/pointer seat capabilities and guard input handlers against missing capabilities
- make Honey OpenXR smoke report `visual_first_frame=P4_FAILED` when an attended observer records `visual_observed=no`
- repaint DRM outputs after surface commits, layout changes, workspace visibility changes, and focus changes

## Root Cause

On yoga, udev enumeration is nondeterministic. When the packaged compositor sees Intel `card1` first, it reaches `Wayland socket: /run/user/1000/wayland-0` and the local session works. When it sees connectorless NVIDIA `card0` first, Mesa/GBM work starts on that offload device and the process can block before the Wayland listener is created.

A later attended black-screen check also exposed an input-path panic: the compositor created the Smithay seat but had not installed keyboard/pointer capabilities before libinput events arrived.

On Honey, the attended goggles report is black, not unobserved, so the smoke wrapper must classify `visual_observed=no` as P4 failed while keeping `not_observed` separate. A live Honey Dell check also showed that the compositor could map XWayland windows without scheduling a new DRM render after the client surface changed, leaving the first dark frame on screen.

## Honey Live Diagnostic

A bounded Honey restart with `EWWM_DRM_TEST_PATTERN=white`, `EWWM_DRM_READBACK=1`, and debug DRM logging produced an all-white framebuffer readback on `HDMI-A-1` and a vblank event after queueing. That proves the compositor can render and submit a non-black scanout buffer on the Dell path. If the physical Dell panel remains black during that white-pattern run, the remaining failure is below compositor rendering.

## Validation

- `git diff --check`
- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`
- `emacs --batch -L lisp/core -L lisp/vr -l test/compositor-test.el -f ert-run-tests-batch-and-exit`
- `emacs --batch -L lisp/core -L lisp/vr -l test/honey-substrate-test.el -f ert-run-tests-batch-and-exit`
- `emacs --batch -L lisp/core -L lisp/vr -l test/truth-surface-test.el -f ert-run-tests-batch-and-exit`
- `just truth-lint`
- local fake OpenXR timeout smoke with `EXWM_VR_VISUAL_OBSERVED=no` -> `visual_first_frame=P4_FAILED`
- `ssh yoga ... journalctl` confirmed the current installed package hit the pre-fix `src/input.rs:72` panic
- `ssh honey ... exwm-vr-openxr-smoke --timeout 30` reached `P3_OPENXR_SESSION`; lab-visible goggles remained black
- Honey white-pattern readback: `mean_abgr=[255,255,255,255]`, `nonzero_bytes=8294400`, followed by DRM vblank

`cargo fmt --manifest-path compositor/Cargo.toml --check` is still blocked locally by a broken Nix `rustfmt` dylib on the Mac host. `cargo test --manifest-path compositor/Cargo.toml --lib render_request_latches_until_taken --no-default-features` is blocked locally at link by missing `xkbcommon`; the Rust test is present and CI will compile it on Linux.

## Tracker

Refs #22, #49.

Yoga evidence packet: https://github.com/Jesssullivan/XoxdWM/issues/22#issuecomment-4455869954