### PR TITLE
[codex] Flush Beyond HID IPC commands

### DIFF
--- a/compositor/src/backend/drm.rs
+++ b/compositor/src/backend/drm.rs
@@ -212,7 +212,8 @@ fn device_added(
             warn!(
                 ?path,
                 ?node,
-                "failed to read DRM connectors before renderer init: {}", e
+                "failed to read DRM connectors before renderer init: {}",
+                e
             );
             0
         }

--- a/compositor/src/ipc/dispatch.rs
+++ b/compositor/src/ipc/dispatch.rs
@@ -3295,19 +3295,23 @@ fn handle_beyond_status(state: &mut EwwmState, msg_id: i64) -> Option<String> {
 }
 
 fn handle_beyond_detect(state: &mut EwwmState, msg_id: i64) -> Option<String> {
-    // Scan for connected Beyond headset. In a full implementation this
-    // would enumerate /dev/hidraw* for BEYOND_VENDOR_ID:BEYOND_PRODUCT_ID_HMD.
-    // For now, assume connected if we get this far (user explicitly asking).
-    state.vr_state.beyond_hid.detect(true, None);
-    let sexp = state.vr_state.beyond_hid.status_sexp();
-    Some(format!(
-        "(:type :response :id {} :status :ok :beyond {})",
-        msg_id, sexp
-    ))
+    match beyond_detect_hidraw(state) {
+        Ok(()) => {
+            let sexp = state.vr_state.beyond_hid.status_sexp();
+            Some(format!(
+                "(:type :response :id {} :status :ok :beyond {})",
+                msg_id, sexp
+            ))
+        }
+        Err(e) => Some(error_response(msg_id, &e)),
+    }
 }
 
 fn handle_beyond_power_on(state: &mut EwwmState, msg_id: i64) -> Option<String> {
-    match state.vr_state.beyond_hid.power_on_display() {
+    match beyond_detect_hidraw(state)
+        .and_then(|_| state.vr_state.beyond_hid.power_on_display())
+        .and_then(|_| beyond_process_pending(state))
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
@@ -3322,7 +3326,10 @@ fn handle_beyond_set_brightness(
         Some(v) => v as u8,
         None => return Some(error_response(msg_id, "missing :value (0-100)")),
     };
-    match state.vr_state.beyond_hid.set_brightness(pct) {
+    match beyond_detect_hidraw(state)
+        .and_then(|_| state.vr_state.beyond_hid.set_brightness(pct))
+        .and_then(|_| beyond_process_pending(state))
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
@@ -3337,7 +3344,10 @@ fn handle_beyond_set_fan_speed(
         Some(v) => v as u8,
         None => return Some(error_response(msg_id, "missing :value (40-100)")),
     };
-    match state.vr_state.beyond_hid.set_fan_speed(pct) {
+    match beyond_detect_hidraw(state)
+        .and_then(|_| state.vr_state.beyond_hid.set_fan_speed(pct))
+        .and_then(|_| beyond_process_pending(state))
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
@@ -3360,10 +3370,54 @@ fn handle_beyond_set_led_color(
         Some(v) => v as u8,
         None => return Some(error_response(msg_id, "missing :b (0-255)")),
     };
-    match state.vr_state.beyond_hid.set_led_color(r, g, b) {
+    match beyond_detect_hidraw(state)
+        .and_then(|_| state.vr_state.beyond_hid.set_led_color(r, g, b))
+        .and_then(|_| beyond_process_pending(state))
+    {
         Ok(()) => Some(ok_response(msg_id)),
         Err(e) => Some(error_response(msg_id, &e)),
     }
+}
+
+#[cfg(target_os = "linux")]
+fn beyond_detect_hidraw(state: &mut EwwmState) -> Result<(), String> {
+    let (dev_path, _name, serial) = crate::vr::beyond_hid::LinuxHidTransport::find_beyond()?;
+    state
+        .vr_state
+        .beyond_hid
+        .detect(true, (!serial.is_empty()).then_some(serial));
+    state
+        .vr_state
+        .beyond_hid
+        .set_discovered_hidraw_path(Some(dev_path));
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn beyond_detect_hidraw(state: &mut EwwmState) -> Result<(), String> {
+    state.vr_state.beyond_hid.detect(true, None);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn beyond_process_pending(state: &mut EwwmState) -> Result<(), String> {
+    let path = state
+        .vr_state
+        .beyond_hid
+        .discovered_hidraw_path
+        .clone()
+        .ok_or_else(|| "no Bigscreen Beyond hidraw path discovered".to_string())?;
+    let mut transport = crate::vr::beyond_hid::LinuxHidTransport::open(&path)?;
+    state
+        .vr_state
+        .beyond_hid
+        .process_pending(&mut transport)
+        .map(|_| ())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn beyond_process_pending(_state: &mut EwwmState) -> Result<(), String> {
+    Err("Bigscreen Beyond hidraw transport is only available on Linux".to_string())
 }
 
 fn handle_beyond_firmware_version(state: &mut EwwmState, msg_id: i64) -> Option<String> {

--- a/test/honey-display-regression-test.el
+++ b/test/honey-display-regression-test.el
@@ -88,5 +88,22 @@
     (should (string-match-p "drm framebuffer readback" content))
     (should (string-match-p "center_pixel" content))))
 
+(ert-deftest honey-display-regression/beyond-ipc-flushes-hid-queue ()
+  "Beyond IPC commands should not report success while HID reports remain queued."
+  (let ((dispatch (honey-display-regression--read-file
+                   "compositor/src/ipc/dispatch.rs")))
+    (dolist (handler '("handle_beyond_power_on"
+                       "handle_beyond_set_brightness"
+                       "handle_beyond_set_fan_speed"
+                       "handle_beyond_set_led_color"))
+      (should (string-match-p handler dispatch)))
+    (should (string-match-p "fn beyond_detect_hidraw" dispatch))
+    (should (string-match-p "LinuxHidTransport::find_beyond" dispatch))
+    (should (string-match-p "fn beyond_process_pending" dispatch))
+    (should (string-match-p "process_pending(&mut transport)" dispatch))
+    (should (string-match-p
+             "and_then(|_| beyond_process_pending(state))"
+             dispatch))))
+
 (provide 'honey-display-regression-test)
 ;;; honey-display-regression-test.el ends here


### PR DESCRIPTION
## Summary

- flush queued Bigscreen Beyond HID commands from mutating native IPC handlers
- remember the detected Linux hidraw path from `:beyond-detect` so direct flushes target the current device
- add a regression guard that fails when `:beyond-power-on` only queues without sending reports

## Root cause

Honey accepted native Beyond IPC commands and returned `:status :ok`, but the installed no-`vr` compositor only queued the HID command. Nothing drained the queue, so runtime diagnostics showed `pending-command-count 1`, `reports-sent 0`, and `last-action "queued:power-on"` while the goggles stayed black.

The standalone helper could power the current `/dev/hidraw2`, which confirmed permissions and packet emission were available outside the IPC path.

## Validation

- `git diff --check`
- `DYLD_LIBRARY_PATH=/nix/store/sdszli3q4p2marqmg0cgmcpa5r2ij3y8-rustc-1.95.0-nightly-2026-02-12-aarch64-apple-darwin/lib cargo fmt --manifest-path compositor/Cargo.toml --check`
- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`
- `just test-compositor`
- `emacs --batch -Q -L lisp/core -L lisp/vr -L lisp/ext -l test/honey-display-regression-test.el -f ert-run-tests-batch-and-exit`
- `just ipc-contract-test`
- `just native-authority-test`
- `just truth-lint`

Stacked on #106.
