### PR TITLE
[codex] Keep Honey surface IPC geometry nonzero

### DIFF
--- a/compositor/src/handlers/xdg_shell.rs
+++ b/compositor/src/handlers/xdg_shell.rs
@@ -131,17 +131,12 @@ impl XdgShellHandler for EwwmState {
     }
 
     fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
-        // Find surface_id by matching the WlSurface
         let wl_surface = surface.wl_surface().clone();
-        let surface_id = self.surfaces.iter().find_map(|(id, _data)| {
-            // Match by checking space elements
-            self.space
-                .elements()
-                .any(|w| {
-                    w.toplevel()
-                        .map(|t| *t.wl_surface() == wl_surface)
-                        .unwrap_or(false)
-                })
+        let surface_id = self.surface_to_window.iter().find_map(|(id, window)| {
+            window
+                .toplevel()
+                .map(|t| *t.wl_surface() == wl_surface)
+                .unwrap_or(false)
                 .then_some(*id)
         });
 

--- a/compositor/src/ipc/dispatch.rs
+++ b/compositor/src/ipc/dispatch.rs
@@ -1,7 +1,7 @@
 //! IPC message dispatch — parse s-expressions and route to handlers.
 
 use super::server::IpcServer;
-use crate::state::EwwmState;
+use crate::state::{EwwmState, SurfaceData};
 use lexpr::Value;
 use tracing::{debug, warn};
 
@@ -340,13 +340,7 @@ fn handle_surface_list(state: &mut EwwmState, msg_id: i64) -> Option<String> {
         let x11_flag = if data.is_x11 { "t" } else { "nil" };
         let x11_class = data.x11_class.as_deref().unwrap_or("");
         let x11_instance = data.x11_instance.as_deref().unwrap_or("");
-        // Get geometry for this specific surface's Window
-        let geo = state
-            .surface_to_window
-            .get(id)
-            .and_then(|w| state.space.element_geometry(w))
-            .map(|g| (g.loc.x, g.loc.y, g.size.w, g.size.h))
-            .unwrap_or((0, 0, 0, 0));
+        let geo = surface_geometry_for_ipc(state, *id, data);
 
         let focused = state.focused_surface == Some(*id);
         surfaces_sexp.push_str(&format!(
@@ -414,12 +408,7 @@ fn handle_surface_info(state: &mut EwwmState, msg_id: i64, value: &Value) -> Opt
     let x11_instance = data.x11_instance.as_deref().unwrap_or("");
     let focused = state.focused_surface == Some(surface_id);
 
-    let geo = state
-        .surface_to_window
-        .get(&surface_id)
-        .and_then(|w| state.space.element_geometry(w))
-        .map(|g| (g.loc.x, g.loc.y, g.size.w, g.size.h))
-        .unwrap_or((0, 0, 0, 0));
+    let geo = surface_geometry_for_ipc(state, surface_id, data);
 
     Some(format!(
         "(:type :response :id {} :status :ok :surface-id {} :app-id \"{}\" :title \"{}\" :protocol \"{}\" :x11 {} :x11-class \"{}\" :x11-instance \"{}\" :geometry (:x {} :y {} :w {} :h {}) :workspace {} :floating {} :focused {})",
@@ -436,6 +425,27 @@ fn handle_surface_info(state: &mut EwwmState, msg_id: i64, value: &Value) -> Opt
         if data.floating { "t" } else { "nil" },
         if focused { "t" } else { "nil" },
     ))
+}
+
+fn surface_geometry_for_ipc(
+    state: &EwwmState,
+    surface_id: u64,
+    data: &SurfaceData,
+) -> (i32, i32, i32, i32) {
+    let configured = (
+        data.geometry.loc.x,
+        data.geometry.loc.y,
+        data.geometry.size.w,
+        data.geometry.size.h,
+    );
+
+    state
+        .surface_to_window
+        .get(&surface_id)
+        .and_then(|w| state.space.element_geometry(w))
+        .map(|g| (g.loc.x, g.loc.y, g.size.w, g.size.h))
+        .filter(|(_, _, w, h)| *w > 0 && *h > 0)
+        .unwrap_or(configured)
 }
 
 fn handle_surface_focus(state: &mut EwwmState, msg_id: i64, value: &Value) -> Option<String> {

--- a/test/honey-display-regression-test.el
+++ b/test/honey-display-regression-test.el
@@ -39,6 +39,13 @@
     (should (string-match-p "State::Activated" content))
     (should (string-match-p "surface.send_configure()" content))))
 
+(ert-deftest honey-display-regression/xdg-destroy-removes-matching-surface-id ()
+  "Destroyed XDG windows should remove the surface ID that owns the wl_surface."
+  (let ((content (honey-display-regression--read-file
+                  "compositor/src/handlers/xdg_shell.rs")))
+    (should (string-match-p "surface_to_window.iter().find_map" content))
+    (should (string-match-p "then_some(\\*id)" content))))
+
 (ert-deftest honey-display-regression/xwayland-maps-with-visible-initial-geometry ()
   "XWayland windows should not use a zero bbox as first configure geometry."
   (let ((content (honey-display-regression--read-file
@@ -70,6 +77,17 @@
     (should (string-match-p "remove_detected_output" output-management))
     (dolist (content (list drm headless winit))
       (should (string-match-p "upsert_detected_output" content)))))
+
+(ert-deftest honey-display-regression/surface-list-falls-back-to-configured-geometry ()
+  "IPC surface geometry should not collapse to 0x0 when Smithay lookup is empty."
+  (let ((content (honey-display-regression--read-file
+                  "compositor/src/ipc/dispatch.rs")))
+    (should (string-match-p "surface_geometry_for_ipc" content))
+    (should (string-match-p "data.geometry.loc.x" content))
+    (should (string-match-p
+             (regexp-quote ".filter(|(_, _, w, h)| *w > 0 && *h > 0)")
+             content))
+    (should (string-match-p "unwrap_or(configured)" content))))
 
 (ert-deftest honey-display-regression/drm-has-operator-visible-test-pattern ()
   "DRM lab mode should support an explicit visible framebuffer pattern."


### PR DESCRIPTION
## Summary

- keep native `:surface-list` / `:surface-info` geometry nonzero by falling back to the compositor configured rectangle when Smithay element lookup has no positive size
- remove destroyed XDG windows by matching the stored `surface_to_window` entry instead of returning an unrelated surface ID from the surface map
- extend the Honey display regression suite for both live-lab failure modes

## Live Honey evidence

- `weston-terminal` connected to `/run/user/1000/wayland-0`, received `xdg_toplevel.configure(...)`, committed SHM buffers, and got frame callbacks.
- Native IPC still reported the live Wayland terminal as `:geometry (:x 0 :y 0 :w 0 :h 0)` and `:focused nil`.
- This patch fixes the IPC/bookkeeping side so future Dell black-screen evidence does not collapse visible configured windows into `0x0` diagnostics.

## Validation

- `git diff --check`
- `DYLD_LIBRARY_PATH=/nix/store/sdszli3q4p2marqmg0cgmcpa5r2ij3y8-rustc-1.95.0-nightly-2026-02-12-aarch64-apple-darwin/lib cargo fmt --manifest-path compositor/Cargo.toml --check`
- `cargo check --manifest-path compositor/Cargo.toml --bin ewwm-compositor --no-default-features`
- `just test-compositor` (Darwin path: `cargo check --tests`, existing warnings)
- `emacs --batch -Q -L lisp/core -L lisp/vr -L lisp/ext -l test/honey-display-regression-test.el -f ert-run-tests-batch-and-exit`
- `just ipc-contract-test`
- `just native-authority-test`
- `just truth-lint`

Stacked on #107.
