### PR TITLE
[codex] Keep Honey OpenXR smoke stdin alive

### DIFF
--- a/docs/honey-p4-visual-first-frame-evidence-template.md
+++ b/docs/honey-p4-visual-first-frame-evidence-template.md
@@ -71,6 +71,10 @@ Command:
 just honey-openxr-smoke honey -- --timeout 120
 ```
 
+The streamed wrapper keeps the OpenXR client's stdin open during bounded runs
+so `hello_xr` stays alive for the observation window instead of exiting as soon
+as the SSH script input reaches EOF.
+
 If the lab observer sees visible non-black headset output during the active
 session, rerun or launch the smoke with the explicit P4 confirmation gate:
 

--- a/docs/remote-proof-lanes.md
+++ b/docs/remote-proof-lanes.md
@@ -135,6 +135,8 @@ The repo now has a thin explicit remote-dev/operator lane for working from
 - `just honey-openxr-smoke`
   - stream the current local repo-owned OpenXR wrapper to `honey` and run it
     against the active Monado runtime
+  - bounded runs keep the client stdin open so `hello_xr` remains alive for
+    the requested observation window rather than exiting on streamed-script EOF
   - this can launch `hello_xr` or another OpenXR client, so use it only when
     the compositor/Monado path is intentionally active
 - `just honey-openxr-clean-cycle`

--- a/packaging/scripts/exwm-vr-openxr-smoke
+++ b/packaging/scripts/exwm-vr-openxr-smoke
@@ -21,6 +21,8 @@ Environment:
   EXWM_VR_OPENXR_ACCEPT_TIMEOUT_AFTER_READY=1
                             Classify a timeout as P3 OpenXR session evidence
                             if READY/client markers are present.
+  EXWM_VR_OPENXR_HOLD_STDIN=0|1
+                            Keep client stdin open during bounded runs. Default: 1.
   EXWM_VR_VISUAL_OBSERVED=yes|no|not_observed
                             Human-visible headset result. Default: no.
   EXWM_VR_VISUAL_OBSERVER  Required when EXWM_VR_VISUAL_OBSERVED=yes.
@@ -33,6 +35,7 @@ status_only=0
 client_override="${EXWM_VR_OPENXR_CLIENT:-}"
 timeout_seconds="${EXWM_VR_OPENXR_TIMEOUT:-20}"
 accept_timeout_after_ready="${EXWM_VR_OPENXR_ACCEPT_TIMEOUT_AFTER_READY:-0}"
+hold_stdin="${EXWM_VR_OPENXR_HOLD_STDIN:-1}"
 visual_observed="${EXWM_VR_VISUAL_OBSERVED:-no}"
 visual_observer="${EXWM_VR_VISUAL_OBSERVER:-}"
 visual_confirmation="${EXWM_VR_VISUAL_CONFIRMATION:-}"
@@ -105,6 +108,13 @@ visual_first_frame_status() {
         yes) echo "P4_OBSERVED" ;;
         no) echo "P4_FAILED" ;;
         not_observed) echo "P4_UNOBSERVED" ;;
+    esac
+}
+
+hold_stdin_enabled() {
+    case "$hold_stdin" in
+        ""|0|false|FALSE|no|NO) return 1 ;;
+        *) return 0 ;;
     esac
 }
 
@@ -267,8 +277,13 @@ else
         echo "ERROR: timeout command not found; set EXWM_VR_OPENXR_TIMEOUT=0 to run unbounded." >&2
         exit 127
     fi
-    timeout "$timeout_seconds" "$client_path" "${client_args[@]}" 2>&1 | tee "$run_log"
-    rc=${PIPESTATUS[0]}
+    if hold_stdin_enabled; then
+        tail -f /dev/null | timeout "$timeout_seconds" "$client_path" "${client_args[@]}" 2>&1 | tee "$run_log"
+        rc=${PIPESTATUS[1]}
+    else
+        timeout "$timeout_seconds" "$client_path" "${client_args[@]}" 2>&1 | tee "$run_log"
+        rc=${PIPESTATUS[0]}
+    fi
 fi
 set -e
 

--- a/test/honey-substrate-test.el
+++ b/test/honey-substrate-test.el
@@ -159,6 +159,21 @@
    nil path nil 'silent)
   (set-file-modes path #o755))
 
+(defun honey-substrate--write-stdin-sensitive-openxr-client (path)
+  "Write a fake OpenXR client that fails if stdin is already closed."
+  (write-region
+   (concat "#!/usr/bin/env bash\n"
+           "set -euo pipefail\n"
+           "echo READY\n"
+           "echo xrGetSystem\n"
+           "if read -r _line; then\n"
+           "  exit 0\n"
+           "fi\n"
+           "echo stdin_eof\n"
+           "exit 42\n")
+   nil path nil 'silent)
+  (set-file-modes path #o755))
+
 (defun honey-substrate--run-openxr-smoke (env &rest args)
   "Run the OpenXR smoke wrapper with ENV and ARGS, returning (RC . OUTPUT)."
   (with-temp-buffer
@@ -246,6 +261,8 @@
       (should (string-match-p (regexp-quote "/usr/libexec/exwm-vr/hello_xr") script))
       (should (string-match-p (regexp-quote "exwm-vr-hello-xr") script))
       (should (string-match-p (regexp-quote "/usr/local/bin/hello_xr") script))
+      (should (string-match-p (regexp-quote "EXWM_VR_OPENXR_HOLD_STDIN") script))
+      (should (string-match-p (regexp-quote "tail -f /dev/null | timeout") script))
       (should (string-match-p (regexp-quote "timeout \"$timeout_seconds\"") script))
       (should (string-match-p (regexp-quote "monado_comp_ipc") script))
       (should (string-match-p (regexp-quote "openxr_smoke=p3_session_after_ready_timeout") script))
@@ -259,6 +276,31 @@
       (should (string-match-p (regexp-quote "P4_FAILED") script))
       (should (string-match-p (regexp-quote "P4_UNOBSERVED") script))
       (should-not (string-match-p (regexp-quote "first frame confirmed") script)))))
+
+(ert-deftest honey-substrate/openxr-smoke-holds-stdin-for-bounded-visual-window ()
+  "Bounded smoke should keep stdin open so hello_xr-style clients do not exit."
+  (let* ((root (make-temp-file "honey-openxr-smoke-stdin-" t))
+         (runtime-json (expand-file-name "active_runtime.json" root))
+         (runtime-dir (expand-file-name "runtime" root))
+         (client (expand-file-name "fake-openxr-client" root)))
+    (unwind-protect
+        (progn
+          (make-directory runtime-dir t)
+          (honey-substrate--write-fake-openxr-runtime runtime-json)
+          (honey-substrate--write-stdin-sensitive-openxr-client client)
+          (let ((held
+                 (honey-substrate--run-openxr-smoke
+                  (list (concat "XR_RUNTIME_JSON=" runtime-json)
+                        (concat "XDG_RUNTIME_DIR=" runtime-dir)
+                        (concat "EXWM_VR_OPENXR_CLIENT=" client)
+                        "EXWM_VR_OPENXR_ACCEPT_TIMEOUT_AFTER_READY=1")
+                  "--timeout" "1")))
+            (should (= (car held) 0))
+            (should (string-match-p
+                     "openxr_smoke=p3_session_after_ready_timeout"
+                     (cdr held)))
+            (should-not (string-match-p "stdin_eof" (cdr held)))))
+      (delete-directory root t))))
 
 (ert-deftest honey-substrate/openxr-smoke-requires-human-confirmation-for-p4 ()
   "P4 observed output should require an explicit human confirmation token."


### PR DESCRIPTION
## Summary

- keep OpenXR smoke client stdin open during bounded runs so `hello_xr` stays alive for the observation window
- add `EXWM_VR_OPENXR_HOLD_STDIN=0` as an escape hatch for clients that should inherit EOF behavior
- document the streamed-wrapper behavior in the Honey P4 template and remote proof lane

## Root cause

The local wrapper is streamed to Honey over SSH. After `bash -s` consumes the script body, client stdin can already be at EOF. `hello_xr` treats stdin as its shutdown channel, so it can reach Bigscreen/Monado swapchains and then exit immediately instead of holding the visual inspection window.

## Validation

- `git diff --check`
- `bash -n packaging/scripts/exwm-vr-openxr-smoke`
- `emacs --batch -Q -L lisp/core -L lisp/vr -L lisp/ext -l test/honey-substrate-test.el -f ert-run-tests-batch-and-exit`
- `just truth-lint`

Stacked on #108.



## Live Honey Check

- `EXWM_VR_OPENXR_ACCEPT_TIMEOUT_AFTER_READY=1 EXWM_VR_VISUAL_OBSERVED=no just honey-openxr-smoke honey -- --timeout 10`
- Result: `openxr_smoke=p3_session_after_ready_timeout`, `proof_ladder=P3_OPENXR_SESSION`, `visual_first_frame=P4_FAILED`.
- This confirms the streamed wrapper now holds `hello_xr` for the bounded window instead of exiting on stdin EOF.
